### PR TITLE
Add fmt and clippy

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,23 @@
+name: Rust
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        components: rustfmt, clippy
+        override: true
+    - name: Check Formatting
+      run: cargo fmt -- --check
+    - name: Run Clippy
+      run: cargo clippy -- -D warnings


### PR DESCRIPTION
This commit adds Rustfmt and Clippy checks to the GitHub Actions CI workflow. These checks ensure code formatting consistency and catch common mistakes, running on every PR to the main branch.