### PR TITLE
V0.0.5 -> V0.0.6 Compatibilty account_balance endpoint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["runner"]
+members = ["runner", "v0-0-5", "v0-0-6"]
 
 [workspace.package]
 version = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["runner", "v0-0-5", "v0-0-6"]
+members = ["runner", "shared", "v0-0-5", "v0-0-6"]
 
 [workspace.package]
 version = "0.1.0"
@@ -40,6 +40,6 @@ async-trait = "0.1.68"
 auto_impl = "1.0.1"
 log = "0.4.19"
 starknet-accounts = "0.9.0"
-
 starknet-signers = "0.8.0"
 sha3 = { version = "0.10.7", default-features = false }
+colored = "2.1.0"

--- a/README.md
+++ b/README.md
@@ -24,3 +24,14 @@ If you want to run a specific test, such as jsonrpc_add_declare_transaction, use
 ```bash
 cargo test jsonrpc_add_declare_transaction -- --nocapture
 ```
+
+## Checking compatibility
+
+To check compatibility for certain version run
+
+```bash
+cargo run -p runner -- --vers <version> --url <url>
+```
+
+example version: v5
+example url: "http://127.0.0.1:5050"

--- a/runner/Cargo.toml
+++ b/runner/Cargo.toml
@@ -23,3 +23,4 @@ starknet-crypto.workspace = true
 serde_json_pythonic.workspace = true
 starknet-signers.workspace = true
 sha3.workspace = true
+shared = { path = "../shared" }

--- a/runner/src/args.rs
+++ b/runner/src/args.rs
@@ -1,4 +1,5 @@
 use clap::Parser;
+use shared::account_balance::Version;
 use starknet_crypto::FieldElement;
 
 #[derive(Parser, Debug, Clone)]
@@ -6,4 +7,10 @@ use starknet_crypto::FieldElement;
 pub struct Args {
     #[arg(long, short, env)]
     pub sender_address: FieldElement,
+
+    #[arg(long, short, env)]
+    pub vers: Version,
+
+    #[arg(long, short, env)]
+    pub url: String,
 }

--- a/runner/src/errors.rs
+++ b/runner/src/errors.rs
@@ -2,6 +2,7 @@ use thiserror::Error;
 use url::ParseError;
 
 #[derive(Debug, Error)]
+#[allow(dead_code)]
 pub enum RunnerError {
     #[error("failed to parse url")]
     ParsingError(#[from] ParseError),

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -5,10 +5,17 @@ mod utils;
 use args::Args;
 use clap::Parser;
 mod tests;
+use shared::account_balance::{account_balance, AccountBalanceParams};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let _args: Args = Args::parse();
+    let account_balance_params = AccountBalanceParams {
+        address: "0x64b48806902a367c8598f4f95c305e8c1a1acba5f082d294a43793113115691".to_string(),
+        unit: "WEI".to_string(),
+        block_tag: "latest".to_string(),
+    };
+    account_balance(&account_balance_params, &_args.vers, &_args.url).await?;
 
     Ok(())
 }

--- a/runner/src/transports/http.rs
+++ b/runner/src/transports/http.rs
@@ -27,6 +27,7 @@ struct JsonRpcRequest<T> {
     params: T,
 }
 
+#[allow(dead_code)]
 impl HttpTransport {
     pub fn new(url: impl Into<Url>) -> Self {
         Self::new_with_client(url, Client::new())

--- a/runner/src/transports/mod.rs
+++ b/runner/src/transports/mod.rs
@@ -190,6 +190,7 @@ struct Felt(#[serde_as(as = "UfeHex")] pub FieldElement);
 #[derive(Serialize, Deserialize)]
 struct FeltArray(#[serde_as(as = "Vec<UfeHex>")] pub Vec<FieldElement>);
 
+#[allow(dead_code)]
 impl<T> JsonRpcClient<T> {
     pub fn new(transport: T) -> Self {
         Self { transport }

--- a/runner/src/utils/accounts.rs
+++ b/runner/src/utils/accounts.rs
@@ -4,6 +4,7 @@ use super::codegen::FlattenedSierraClass;
 use starknet_crypto::{FieldElement, PoseidonHasher};
 /// [DeclarationV3] but with `nonce`, `gas` and `gas_price` already determined.
 #[derive(Debug)]
+#[allow(dead_code)]
 pub struct RawDeclarationV3 {
     pub contract_class: Arc<FlattenedSierraClass>,
     pub compiled_class_hash: FieldElement,
@@ -11,6 +12,7 @@ pub struct RawDeclarationV3 {
     pub gas: u64,
     pub gas_price: u128,
 }
+#[allow(dead_code)]
 /// Cairo string for "declare"
 const PREFIX_DECLARE: FieldElement = FieldElement::from_mont([
     17542456862011667323,
@@ -19,6 +21,7 @@ const PREFIX_DECLARE: FieldElement = FieldElement::from_mont([
     191557713328401194,
 ]);
 
+#[allow(dead_code)]
 /// 2 ^ 128 + 1
 const QUERY_VERSION_ONE: FieldElement = FieldElement::from_mont([
     18446744073700081633,
@@ -27,6 +30,7 @@ const QUERY_VERSION_ONE: FieldElement = FieldElement::from_mont([
     576460752142433776,
 ]);
 
+#[allow(dead_code)]
 /// 2 ^ 128 + 2
 const QUERY_VERSION_TWO: FieldElement = FieldElement::from_mont([
     18446744073700081601,
@@ -35,6 +39,7 @@ const QUERY_VERSION_TWO: FieldElement = FieldElement::from_mont([
     576460752142433232,
 ]);
 
+#[allow(dead_code)]
 /// 2 ^ 128 + 3
 const QUERY_VERSION_THREE: FieldElement = FieldElement::from_mont([
     18446744073700081569,
@@ -43,6 +48,7 @@ const QUERY_VERSION_THREE: FieldElement = FieldElement::from_mont([
     576460752142432688,
 ]);
 
+#[allow(dead_code)]
 impl RawDeclarationV3 {
     pub fn transaction_hash(
         &self,

--- a/runner/src/utils/byte_array.rs
+++ b/runner/src/utils/byte_array.rs
@@ -1,3 +1,4 @@
+#[allow(dead_code)]
 pub mod base64 {
 
     use std::fmt::{self, Formatter};

--- a/runner/src/utils/codegen.rs
+++ b/runner/src/utils/codegen.rs
@@ -414,6 +414,7 @@ impl core::fmt::Display for StarknetError {
     }
 }
 
+#[allow(dead_code)]
 impl StarknetError {
     pub fn message(&self) -> &'static str {
         match self {

--- a/runner/src/utils/contract/legacy.rs
+++ b/runner/src/utils/contract/legacy.rs
@@ -29,6 +29,8 @@ use starknet_crypto::FieldElement;
 use std::collections::BTreeMap;
 
 use super::ComputeClassHashError;
+
+#[allow(dead_code)]
 const API_VERSION: FieldElement = FieldElement::ZERO;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -279,6 +281,7 @@ pub struct RawLegacyMember {
     pub r#type: String,
 }
 
+#[allow(dead_code)]
 struct ProgramForHintedHash;
 struct AttributeForHintedHash;
 
@@ -396,6 +399,7 @@ impl<'de> Deserialize<'de> for RawLegacyAbiEntry {
     }
 }
 
+#[allow(dead_code)]
 impl LegacyContractClass {
     pub fn class_hash(&self) -> Result<FieldElement, ComputeClassHashError> {
         let mut elements = Vec::new();

--- a/runner/src/utils/contract/mod.rs
+++ b/runner/src/utils/contract/mod.rs
@@ -407,6 +407,7 @@ use super::{
     },
 };
 
+#[allow(dead_code)]
 impl SierraClass {
     pub fn class_hash(&self) -> Result<FieldElement, ComputeClassHashError> {
         // Technically we don't have to use the Pythonic JSON style here. Doing this just to align

--- a/runner/src/utils/crypto.rs
+++ b/runner/src/utils/crypto.rs
@@ -1,6 +1,7 @@
 pub use starknet_crypto::{pedersen_hash, ExtendedSignature, Signature};
 use starknet_crypto::{rfc6979_generate_k, sign, verify, FieldElement, SignError, VerifyError};
 
+#[allow(dead_code)]
 mod errors {
     use core::fmt::{Display, Formatter, Result};
 
@@ -44,6 +45,7 @@ mod errors {
 }
 pub use errors::{EcdsaSignError, EcdsaVerifyError};
 
+#[allow(dead_code)]
 pub fn compute_hash_on_elements(data: &[FieldElement]) -> FieldElement {
     let mut current_hash = FieldElement::ZERO;
 
@@ -55,6 +57,7 @@ pub fn compute_hash_on_elements(data: &[FieldElement]) -> FieldElement {
     pedersen_hash(&current_hash, &data_len)
 }
 
+#[allow(dead_code)]
 pub fn ecdsa_sign(
     private_key: &FieldElement,
     message_hash: &FieldElement,
@@ -82,6 +85,7 @@ pub fn ecdsa_sign(
     }
 }
 
+#[allow(dead_code)]
 pub fn ecdsa_verify(
     public_key: &FieldElement,
     message_hash: &FieldElement,

--- a/runner/src/utils/mod.rs
+++ b/runner/src/utils/mod.rs
@@ -10,6 +10,7 @@ use codegen::{
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use starknet_crypto::FieldElement;
+#[allow(dead_code)]
 /// Cairo string for "CONTRACT_CLASS_V0.1.0"
 const PREFIX_CONTRACT_CLASS_V0_1_0: FieldElement = FieldElement::from_mont([
     5800711240972404213,
@@ -18,6 +19,7 @@ const PREFIX_CONTRACT_CLASS_V0_1_0: FieldElement = FieldElement::from_mont([
     37302452645455172,
 ]);
 
+#[allow(dead_code)]
 /// Cairo string for "COMPILED_CLASS_V1"
 const PREFIX_COMPILED_CLASS_V1: FieldElement = FieldElement::from_mont([
     2291010424822318237,

--- a/runner/src/utils/provider.rs
+++ b/runner/src/utils/provider.rs
@@ -300,6 +300,7 @@ pub trait Provider {
     // }
 }
 
+#[allow(dead_code)]
 /// Trait for implementation-specific error type. These errors are irrelevant in most cases,
 /// assuming that users typically care more about the specifics of RPC errors instead of the
 /// underlying transport. Therefore, it makes little sense to bloat [ProviderError] with a generic
@@ -311,6 +312,7 @@ pub trait ProviderImplError: Error + Debug + Send + Sync {
     fn as_any(&self) -> &dyn Any;
 }
 
+#[allow(dead_code)]
 #[derive(Debug, thiserror::Error)]
 pub enum ProviderError {
     #[error(transparent)]

--- a/runner/src/utils/serde_impls.rs
+++ b/runner/src/utils/serde_impls.rs
@@ -148,6 +148,7 @@ pub(crate) mod u64_hex {
     }
 }
 
+#[allow(dead_code)]
 pub(crate) mod u128_hex {
     use serde::de::Visitor;
 
@@ -184,6 +185,7 @@ pub(crate) mod u128_hex {
     }
 }
 
+#[allow(dead_code)]
 pub(crate) mod u64_hex_opt {
     use serde::de::Visitor;
 

--- a/runner/src/utils/transaction_request.rs
+++ b/runner/src/utils/transaction_request.rs
@@ -11,6 +11,7 @@ use starknet_crypto::FieldElement;
 
 #[derive(Debug, Serialize)]
 #[serde(tag = "type", rename_all = "SCREAMING_SNAKE_CASE")]
+#[allow(dead_code)]
 pub enum TransactionRequest {
     Declare(DeclareTransaction),
     // InvokeFunction(InvokeFunctionTransaction),
@@ -19,6 +20,7 @@ pub enum TransactionRequest {
 
 #[derive(Debug, Serialize)]
 #[serde(untagged)]
+#[allow(dead_code)]
 pub enum DeclareTransaction {
     // V1(DeclareV1Transaction),
     // V2(DeclareV2Transaction),

--- a/runner/src/utils/unsigned_field_element.rs
+++ b/runner/src/utils/unsigned_field_element.rs
@@ -9,8 +9,10 @@ use starknet_crypto::FieldElement;
 
 pub struct UfeHex;
 
+#[allow(dead_code)]
 pub struct UfeHexOption;
 
+#[allow(dead_code)]
 pub struct UfePendingBlockHash;
 
 struct UfeHexVisitor;

--- a/runner/src/utils/utils.rs
+++ b/runner/src/utils/utils.rs
@@ -1,7 +1,10 @@
 use sha3::{Digest, Keccak256};
 use starknet_crypto::{pedersen_hash, FieldElement};
 
+#[allow(dead_code)]
 const DEFAULT_ENTRY_POINT_NAME: &str = "__default__";
+
+#[allow(dead_code)]
 const DEFAULT_L1_ENTRY_POINT_NAME: &str = "__l1_default__";
 
 // 2 ** 251 - 256
@@ -12,6 +15,7 @@ const ADDR_BOUND: FieldElement = FieldElement::from_mont([
     576459263475590224,
 ]);
 
+#[allow(dead_code)]
 // Cairo string of "STARKNET_CONTRACT_ADDRESS"
 const CONTRACT_ADDRESS_PREFIX: FieldElement = FieldElement::from_mont([
     3829237882463328880,
@@ -20,6 +24,7 @@ const CONTRACT_ADDRESS_PREFIX: FieldElement = FieldElement::from_mont([
     533439743893157637,
 ]);
 
+#[allow(dead_code)]
 /// The uniqueness settings for UDC deployments.
 #[derive(Debug, Clone)]
 pub enum UdcUniqueness {
@@ -27,12 +32,14 @@ pub enum UdcUniqueness {
     Unique(UdcUniqueSettings),
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct UdcUniqueSettings {
     pub deployer_address: FieldElement,
     pub udc_contract_address: FieldElement,
 }
 
+#[allow(dead_code)]
 mod errors {
     use core::fmt::{Display, Formatter, Result};
 
@@ -115,6 +122,7 @@ pub fn starknet_keccak(data: &[u8]) -> FieldElement {
     FieldElement::from_bytes_be(unsafe { &*(hash[..].as_ptr() as *const [u8; 32]) }).unwrap()
 }
 
+#[allow(dead_code)]
 pub fn get_selector_from_name(func_name: &str) -> Result<FieldElement, NonAsciiNameError> {
     if func_name == DEFAULT_ENTRY_POINT_NAME || func_name == DEFAULT_L1_ENTRY_POINT_NAME {
         Ok(FieldElement::ZERO)
@@ -128,6 +136,7 @@ pub fn get_selector_from_name(func_name: &str) -> Result<FieldElement, NonAsciiN
     }
 }
 
+#[allow(dead_code)]
 pub fn get_storage_var_address(
     var_name: &str,
     args: &[FieldElement],
@@ -144,6 +153,7 @@ pub fn get_storage_var_address(
     }
 }
 
+#[allow(dead_code)]
 /// Converts Cairo short string to [FieldElement].
 pub fn cairo_short_string_to_felt(str: &str) -> Result<FieldElement, CairoShortStringToFeltError> {
     if !str.is_ascii() {
@@ -162,6 +172,7 @@ pub fn cairo_short_string_to_felt(str: &str) -> Result<FieldElement, CairoShortS
     Ok(FieldElement::from_bytes_be(&buffer).unwrap())
 }
 
+#[allow(dead_code)]
 /// Converts [FieldElement] to Cairo short string.
 pub fn parse_cairo_short_string(felt: &FieldElement) -> Result<String, ParseCairoShortStringError> {
     if felt == &FieldElement::ZERO {
@@ -186,6 +197,7 @@ pub fn parse_cairo_short_string(felt: &FieldElement) -> Result<String, ParseCair
     Ok(buffer)
 }
 
+#[allow(dead_code)]
 /// Computes the target contract address of a "native" contract deployment. Use
 /// `get_udc_deployed_address` instead if you want to compute the target address for deployments
 /// through the Universal Deployer Contract.
@@ -204,6 +216,7 @@ pub fn get_contract_address(
     ]))
 }
 
+#[allow(dead_code)]
 /// Computes the target contract address for deployments through the Universal Deploy Contract.
 pub fn get_udc_deployed_address(
     salt: FieldElement,
@@ -231,10 +244,13 @@ pub fn normalize_address(address: FieldElement) -> FieldElement {
     address % ADDR_BOUND
 }
 
+#[allow(dead_code)]
 pub fn create_jsonrpc_client() -> JsonRpcClient<HttpTransport> {
     let rpc_url = std::env::var("STARKNET_RPC").unwrap_or("http://localhost:5050/".into());
     JsonRpcClient::new(HttpTransport::new(url::Url::parse(&rpc_url).unwrap()))
 }
+
+#[allow(dead_code)]
 pub async fn get_compiled_contract(
     sierra_path: &str,
     casm_path: &str,

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "shared"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+tokio.workspace = true
+reqwest.workspace = true
+serde.workspace = true
+clap.workspace = true
+colored.workspace = true
+v0-0-5 = { path = "../v0-0-5" }
+v0-0-6 = { path = "../v0-0-6" }
+
+[path]
+src = "src/lib.rs"

--- a/shared/src/account_balance.rs
+++ b/shared/src/account_balance.rs
@@ -28,12 +28,6 @@ pub struct AccountBalanceParams {
     pub block_tag: String,
 }
 
-#[derive(Debug)]
-pub enum AccountBalanceResponse {
-    V0_0_5(AccountBalanceResponseV0_0_5),
-    V0_0_6(AccountBalanceResponseV0_0_6),
-}
-
 pub async fn account_balance(
     account_balance_params: &AccountBalanceParams,
     version: &Version,

--- a/shared/src/account_balance.rs
+++ b/shared/src/account_balance.rs
@@ -1,0 +1,68 @@
+use crate::v0_0_5::account_balance::AccountBalanceResponseV0_0_5;
+use crate::v0_0_6::account_balance::AccountBalanceResponseV0_0_6;
+use clap::Parser;
+use colored::*;
+use reqwest::{Client, Error};
+
+#[derive(Parser, Debug, Clone)]
+pub enum Version {
+    V0_0_6,
+    V0_0_5,
+}
+
+impl std::str::FromStr for Version {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "v6" => Ok(Version::V0_0_6),
+            "v5" => Ok(Version::V0_0_5),
+            _ => Err(format!("'{}' is not a valid version", s)),
+        }
+    }
+}
+
+pub struct AccountBalanceParams {
+    pub address: String,
+    pub unit: String,
+    pub block_tag: String,
+}
+
+#[derive(Debug)]
+pub enum AccountBalanceResponse {
+    V0_0_5(AccountBalanceResponseV0_0_5),
+    V0_0_6(AccountBalanceResponseV0_0_6),
+}
+
+pub async fn account_balance(
+    account_balance_params: &AccountBalanceParams,
+    version: &Version,
+    url: &str,
+) -> Result<(), Error> {
+    let client = Client::new();
+    let url = format!(
+        "{}/account_balance?address={}&unit={}&block_tag={}",
+        url,
+        account_balance_params.address,
+        account_balance_params.unit,
+        account_balance_params.block_tag
+    );
+    let res = client.get(&url).send().await?;
+    match version {
+        Version::V0_0_5 => {
+            let account_balance_response = res.json::<AccountBalanceResponseV0_0_5>().await;
+            match account_balance_response {
+                Ok(_) => println!("{}", "COMPATIBLE".green()),
+                Err(_) => println!("{}", "INCOMPATIBLE".red()),
+            }
+        }
+        Version::V0_0_6 => {
+            let account_balance_response = res.json::<AccountBalanceResponseV0_0_6>().await;
+            match account_balance_response {
+                Ok(_) => println!("{}", "COMPATIBLE".green()),
+                Err(_) => println!("{}", "INCOMPATIBLE".red()),
+            }
+        }
+    };
+    Ok(())
+}

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod account_balance;
+pub use v0_0_5;
+pub use v0_0_6;

--- a/v0-0-5/Cargo.toml
+++ b/v0-0-5/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "v0-0-5"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]

--- a/v0-0-5/Cargo.toml
+++ b/v0-0-5/Cargo.toml
@@ -4,3 +4,7 @@ version.workspace = true
 edition.workspace = true
 
 [dependencies]
+serde.workspace = true
+
+[lib]
+path = "src/lib.rs"

--- a/v0-0-5/src/account_balance.rs
+++ b/v0-0-5/src/account_balance.rs
@@ -1,0 +1,7 @@
+use serde::Deserialize;
+
+#[derive(Deserialize, Debug)]
+pub struct AccountBalanceResponseV0_0_5 {
+    pub amount: (u64, u64, u64),
+    pub unit: String,
+}

--- a/v0-0-5/src/lib.rs
+++ b/v0-0-5/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod account_balance;

--- a/v0-0-5/src/main.rs
+++ b/v0-0-5/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/v0-0-5/src/main.rs
+++ b/v0-0-5/src/main.rs
@@ -1,3 +1,0 @@
-fn main() {
-    println!("Hello, world!");
-}

--- a/v0-0-6/Cargo.toml
+++ b/v0-0-6/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "v0-0-6"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]

--- a/v0-0-6/Cargo.toml
+++ b/v0-0-6/Cargo.toml
@@ -4,3 +4,7 @@ version.workspace = true
 edition.workspace = true
 
 [dependencies]
+serde.workspace = true
+
+[lib]
+path = "src/lib.rs"

--- a/v0-0-6/src/account_balance.rs
+++ b/v0-0-6/src/account_balance.rs
@@ -1,0 +1,7 @@
+use serde::Deserialize;
+
+#[derive(Deserialize, Debug)]
+pub struct AccountBalanceResponseV0_0_6 {
+    pub amount: String,
+    pub unit: String,
+}

--- a/v0-0-6/src/lib.rs
+++ b/v0-0-6/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod account_balance;

--- a/v0-0-6/src/main.rs
+++ b/v0-0-6/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/v0-0-6/src/main.rs
+++ b/v0-0-6/src/main.rs
@@ -1,3 +1,0 @@
-fn main() {
-    println!("Hello, world!");
-}


### PR DESCRIPTION
* user can check compatibility for `v0.0.5` and `v0.0.6`
* to run: `cargo run -p runner -- --vers <version> --url <url>`
* if not compatible then "INCOMPATIBLE" shall occur
* if compatible then "COMPATIBLE" shall occur
* add `allow(dead_code)]` for most clippy errors, 3 remaining, not fixed due to possible issues in the codebase
