### PR TITLE
Create Account Fn

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,3 +39,4 @@ tokio = { version = "1.38.0", features = ["full"] }
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
 url = "2.5.1"
+rand = "0.8.5"

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -4,6 +4,7 @@ use args::Args;
 use clap::Parser;
 mod tests;
 use shared::account_balance::{account_balance, AccountBalanceParams};
+use shared::create_account::create_account;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -19,5 +20,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         block_tag: "latest".to_string(),
     };
     account_balance(&account_balance_params, &args.vers, args.url).await?;
+    create_account();
     Ok(())
 }

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -19,7 +19,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         unit: "WEI".to_string(),
         block_tag: "latest".to_string(),
     };
-    account_balance(&account_balance_params, &args.vers, args.url).await?;
-    create_account();
+    account_balance(&account_balance_params, &args.vers, &args.url).await?;
+    create_account(&args.url).await;
     Ok(())
 }

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -16,3 +16,4 @@ v0-0-6 = { path = "../v0-0-6" }
 starknet-crypto.workspace = true
 starknet-signers.workspace = true
 prefix-hex.workspace = true
+rand.workspace = true

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -14,4 +14,5 @@ tracing.workspace = true
 v0-0-5 = { path = "../v0-0-5" }
 v0-0-6 = { path = "../v0-0-6" }
 starknet-crypto.workspace = true
+starknet-signers.workspace = true
 prefix-hex.workspace = true

--- a/shared/src/account_balance.rs
+++ b/shared/src/account_balance.rs
@@ -38,7 +38,7 @@ pub struct AccountBalanceParams {
 pub async fn account_balance(
     account_balance_params: &AccountBalanceParams,
     version: &Version,
-    base_url: Url,
+    base_url: &Url,
 ) -> Result<(), RequestOrParseError> {
     let client = Client::new();
     let account_balance_url = match base_url.join("account_balance") {

--- a/shared/src/create_account.rs
+++ b/shared/src/create_account.rs
@@ -1,0 +1,62 @@
+use starknet_crypto::{pedersen_hash, FieldElement};
+use starknet_signers::SigningKey;
+
+// Cairo string of "STARKNET_CONTRACT_ADDRESS"
+const CONTRACT_ADDRESS_PREFIX: FieldElement = FieldElement::from_mont([
+    3829237882463328880,
+    17289941567720117366,
+    8635008616843941496,
+    533439743893157637,
+]);
+
+#[derive(Debug)]
+pub struct AccountConfiguration {
+    pub class_hash: FieldElement,
+    pub salt: FieldElement,
+    pub public_key: FieldElement,
+}
+
+pub fn create_account() {
+    let key = SigningKey::from_random();
+    println!("Private Key: {:?}", &key.secret_scalar());
+    println!("Public Key: {:?}", &key.verifying_key().scalar());
+
+    let salt = SigningKey::from_random().secret_scalar();
+    println!("Salt: {:?}", &salt);
+
+    let class_hash = FieldElement::from_hex_be(
+        "0x61dac032f228abef9c6626f995015233097ae253a7f72d68552db02f2971b8f",
+    )
+    .unwrap();
+    println!("Class Hash: {:?}", &class_hash);
+
+    let account_configuration = AccountConfiguration {
+        class_hash,
+        salt,
+        public_key: key.verifying_key().scalar(),
+    };
+    println!("Account Configuration: {:?}", &account_configuration);
+    let deployed_address = get_contract_address(&account_configuration);
+    println!("Deployed Address: {:?}", &deployed_address);
+}
+
+pub fn get_contract_address(account_configuration: &AccountConfiguration) -> FieldElement {
+    compute_hash_on_elements(&[
+        CONTRACT_ADDRESS_PREFIX,
+        FieldElement::ZERO,
+        account_configuration.salt,
+        account_configuration.class_hash,
+        compute_hash_on_elements(&[account_configuration.public_key]),
+    ])
+}
+
+pub fn compute_hash_on_elements(data: &[FieldElement]) -> FieldElement {
+    let mut current_hash = FieldElement::ZERO;
+
+    for item in data.iter() {
+        current_hash = pedersen_hash(&current_hash, item);
+    }
+
+    let data_len = FieldElement::from(data.len());
+    pedersen_hash(&current_hash, &data_len)
+}

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod account_balance;
 pub mod create_account;
 pub mod errors;
+pub mod mint;
 pub mod serialize_felt_to_hex;
 pub use v0_0_5;
 pub use v0_0_6;

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod account_balance;
+pub mod create_account;
 pub mod errors;
 pub mod serialize_felt_to_hex;
 pub use v0_0_5;

--- a/shared/src/mint.rs
+++ b/shared/src/mint.rs
@@ -1,0 +1,41 @@
+use crate::errors::RequestOrParseError;
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use starknet_crypto::FieldElement;
+use url::Url;
+
+#[derive(Serialize, Debug)]
+pub struct MintParams {
+    #[serde(serialize_with = "crate::serialize_felt_to_hex::serialize_field_element")]
+    pub address: FieldElement,
+    pub amount: u128,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct MintResponse {
+    pub new_balance: FieldElement,
+    pub unit: String,
+    pub tx_hash: FieldElement,
+}
+
+pub async fn mint(
+    mint_params: &MintParams,
+    base_url: &Url,
+) -> Result<MintResponse, RequestOrParseError> {
+    let client = Client::new();
+
+    let mint_url = match base_url.join("mint") {
+        Ok(url) => url,
+        Err(e) => return Err(e.into()),
+    };
+
+    let res = match client.post(mint_url).json(mint_params).send().await {
+        Ok(res) => res,
+        Err(e) => return Err(e.into()),
+    };
+    let mint_response = match res.json::<MintResponse>().await {
+        Ok(mint_response) => mint_response,
+        Err(e) => return Err(e.into()),
+    };
+    Ok(mint_response)
+}


### PR DESCRIPTION
* Create account fn in this commit creates configuration with class_hash from starknet devnet, salt and public key derived from SigningKey crate.
* It gets predeployed account addres by computing hash accountn configuration properties.