### PR TITLE
Invoke_contract enpoints 

### DIFF
--- a/checker/src/v5/rpc/accounts/single_owner.rs
+++ b/checker/src/v5/rpc/accounts/single_owner.rs
@@ -99,9 +99,9 @@ where
     async fn sign_execution_v1(
         &self,
         execution: &RawExecutionV1,
-        query_only: bool,
+        _query_only: bool,
     ) -> Result<Vec<Felt>, Self::SignError> {
-        let tx_hash = execution.transaction_hash(self.chain_id, self.address, query_only, self);
+        let tx_hash = execution.transaction_hash(self.chain_id, self.address, false, self);
         let signature = self
             .signer
             .sign_hash(&tx_hash)

--- a/checker/src/v5/rpc/endpoints/endpoints_functions.rs
+++ b/checker/src/v5/rpc/endpoints/endpoints_functions.rs
@@ -16,6 +16,7 @@ use url::Url;
 use crate::v5::rpc::{
     accounts::{
         account::{Account, AccountError, ConnectedAccount},
+        call::Call,
         creation::{
             create::{create_account, AccountType},
             helpers::get_chain_id,
@@ -253,6 +254,153 @@ pub async fn add_invoke_transaction(
             Err(e)
         }
     }
+}
+
+pub async fn invoke_contract(
+    url: Url,
+    sierra_path: &str,
+    casm_path: &str,
+) -> Result<AddInvokeTransactionResult, RpcError> {
+    let (flattened_sierra_class, compiled_class_hash) =
+        get_compiled_contract(sierra_path, casm_path).await.unwrap();
+
+    let provider = JsonRpcClient::new(HttpTransport::new(url.clone()));
+    let create_acc_data =
+        match create_account(&provider, AccountType::Oz, Option::None, Option::None).await {
+            Ok(value) => value,
+            Err(e) => {
+                info!("{}", "Could not create an account");
+                return Err(e.into());
+            }
+        };
+
+    match mint(
+        url.clone(),
+        &MintRequest {
+            amount: u128::MAX,
+            address: create_acc_data.address,
+        },
+    )
+    .await
+    {
+        Ok(_) => {}
+        Err(e) => {
+            info!("{}", "Could not mint tokens");
+            return Err(e.into());
+        }
+    };
+
+    let wait_conifg = WaitForTx {
+        wait: true,
+        wait_params: ValidatedWaitParams::default(),
+    };
+
+    let chain_id = get_chain_id(&provider).await.unwrap();
+
+    match deploy_account(&provider, chain_id, wait_conifg, create_acc_data).await {
+        Ok(value) => Some(value),
+        Err(e) => {
+            info!("{}", "Could not deploy an account");
+            return Err(e.into());
+        }
+    };
+    let sender_address = create_acc_data.address;
+    let signer: LocalWallet = LocalWallet::from(create_acc_data.signing_key);
+
+    let mut account = SingleOwnerAccount::new(
+        JsonRpcClient::new(HttpTransport::new(url.clone())),
+        signer,
+        sender_address,
+        chain_id,
+        ExecutionEncoding::New,
+    );
+
+    account.set_block_id(BlockId::Tag(BlockTag::Latest));
+
+    let hash = match account
+        .declare_v2(Arc::new(flattened_sierra_class), compiled_class_hash)
+        .send()
+        .await
+    {
+        Ok(result) => Ok(result.class_hash),
+        Err(AccountError::Signing(sign_error)) => {
+            if sign_error.to_string().contains("is already declared") {
+                Ok(parse_class_hash_from_error(&sign_error.to_string()))
+            } else {
+                Err(RpcError::RunnerError(RunnerError::AccountFailure(format!(
+                    "Transaction execution error: {}",
+                    sign_error
+                ))))
+            }
+        }
+
+        Err(AccountError::Provider(ProviderError::Other(starkneterror))) => {
+            if starkneterror.to_string().contains("is already declared") {
+                Ok(parse_class_hash_from_error(&starkneterror.to_string()))
+            } else {
+                Err(RpcError::RunnerError(RunnerError::AccountFailure(format!(
+                    "Transaction execution error: {}",
+                    starkneterror
+                ))))
+            }
+        }
+        Err(e) => {
+            info!("General account error encountered: {:?}, possible cause - incorrect address or public_key in environment variables!", e);
+            Err(RpcError::RunnerError(RunnerError::AccountFailure(format!(
+                "Account error: {}",
+                e
+            ))))
+        }
+    };
+
+    let hash = match hash {
+        Ok(class_hash) => {
+            let factory = ContractFactory::new(class_hash, account.clone());
+            let mut salt_buffer = [0u8; 32];
+            let mut rng = StdRng::from_entropy();
+            rng.fill_bytes(&mut salt_buffer[1..]);
+
+            factory
+                .deploy_v1(vec![], Felt::from_bytes_be(&salt_buffer), true)
+                .max_fee(Felt::from_dec_str("100000000000000000").unwrap())
+                .send()
+                .await
+                .unwrap()
+        }
+        Err(e) => {
+            info!("Could not deploy the contract {}", e);
+            return Err(e);
+        }
+    };
+
+    let receipt = account
+        .provider()
+        .get_transaction_receipt(hash.transaction_hash)
+        .await
+        .unwrap();
+
+    let receipt = match receipt {
+        TxnReceipt::Deploy(receipt) => receipt,
+        _ => {
+            info!("Unexpected response type TxnReceipt");
+            Err(RpcError::CallError(CallError::UnexpectedReceiptType))?
+        }
+    };
+
+    match receipt.common_receipt_properties.execution_status {
+        TxnExecutionStatus::Succeeded => {}
+        _ => Err(RpcError::CallError(CallError::UnexpectedExecutionResult))?,
+    }
+
+    let call = Call {
+        to: receipt.contract_address,
+        selector: get_selector_from_name("increase_balance").unwrap(),
+        calldata: vec![Felt::from_hex_unchecked("0x50")],
+    };
+
+    let result = account.execute_v1(vec![call]).send().await.unwrap();
+
+    Ok(result)
 }
 
 pub async fn block_number(url: Url) -> Result<u64, RpcError> {

--- a/checker/src/v6/rpc/accounts/single_owner.rs
+++ b/checker/src/v6/rpc/accounts/single_owner.rs
@@ -102,9 +102,9 @@ where
     async fn sign_execution_v1(
         &self,
         execution: &RawExecutionV1,
-        query_only: bool,
+        _query_only: bool,
     ) -> Result<Vec<Felt>, Self::SignError> {
-        let tx_hash = execution.transaction_hash(self.chain_id, self.address, query_only, self);
+        let tx_hash = execution.transaction_hash(self.chain_id, self.address, false, self);
         let signature = self
             .signer
             .sign_hash(&tx_hash)

--- a/checker/src/v6/rpc/endpoints/endpoints_functions.rs
+++ b/checker/src/v6/rpc/endpoints/endpoints_functions.rs
@@ -16,6 +16,7 @@ use url::Url;
 use crate::v6::rpc::{
     accounts::{
         account::{Account, AccountError, ConnectedAccount},
+        call::Call,
         creation::{
             create::{create_account, AccountType},
             helpers::get_chain_id,
@@ -507,6 +508,318 @@ pub async fn add_invoke_transaction_v3(
             Err(e)
         }
     }
+}
+
+pub async fn invoke_contract_v1(
+    url: Url,
+    sierra_path: &str,
+    casm_path: &str,
+) -> Result<AddInvokeTransactionResult, RpcError> {
+    let (flattened_sierra_class, compiled_class_hash) =
+        get_compiled_contract(sierra_path, casm_path).await.unwrap();
+
+    let provider = JsonRpcClient::new(HttpTransport::new(url.clone()));
+    let create_acc_data =
+        match create_account(&provider, AccountType::Oz, Option::None, Option::None).await {
+            Ok(value) => value,
+            Err(e) => {
+                info!("{}", "Could not create an account");
+                return Err(e.into());
+            }
+        };
+
+    match mint(
+        url.clone(),
+        &MintRequest {
+            amount: u128::MAX,
+            address: create_acc_data.address,
+        },
+    )
+    .await
+    {
+        Ok(_) => {}
+        Err(e) => {
+            info!("{}", "Could not mint tokens");
+            return Err(e.into());
+        }
+    };
+
+    let wait_conifg = WaitForTx {
+        wait: true,
+        wait_params: ValidatedWaitParams::default(),
+    };
+
+    let chain_id = get_chain_id(&provider).await.unwrap();
+
+    match deploy_account(&provider, chain_id, wait_conifg, create_acc_data).await {
+        Ok(value) => Some(value),
+        Err(e) => {
+            info!("{}", "Could not deploy an account");
+            return Err(e.into());
+        }
+    };
+    let sender_address = create_acc_data.address;
+    let signer: LocalWallet = LocalWallet::from(create_acc_data.signing_key);
+
+    let mut account = SingleOwnerAccount::new(
+        JsonRpcClient::new(HttpTransport::new(url.clone())),
+        signer,
+        sender_address,
+        chain_id,
+        ExecutionEncoding::New,
+    );
+
+    account.set_block_id(BlockId::Tag(BlockTag::Latest));
+
+    let hash = match account
+        .declare_v2(Arc::new(flattened_sierra_class), compiled_class_hash)
+        .send()
+        .await
+    {
+        Ok(result) => Ok(result.class_hash),
+        Err(AccountError::Signing(sign_error)) => {
+            if sign_error.to_string().contains("is already declared") {
+                Ok(parse_class_hash_from_error(&sign_error.to_string()))
+            } else {
+                Err(RpcError::RunnerError(RunnerError::AccountFailure(format!(
+                    "Transaction execution error: {}",
+                    sign_error
+                ))))
+            }
+        }
+
+        Err(AccountError::Provider(ProviderError::Other(starkneterror))) => {
+            if starkneterror.to_string().contains("is already declared") {
+                Ok(parse_class_hash_from_error(&starkneterror.to_string()))
+            } else {
+                Err(RpcError::RunnerError(RunnerError::AccountFailure(format!(
+                    "Transaction execution error: {}",
+                    starkneterror
+                ))))
+            }
+        }
+        Err(e) => {
+            info!("General account error encountered: {:?}, possible cause - incorrect address or public_key in environment variables!", e);
+            Err(RpcError::RunnerError(RunnerError::AccountFailure(format!(
+                "Account error: {}",
+                e
+            ))))
+        }
+    };
+
+    let hash = match hash {
+        Ok(class_hash) => {
+            let factory = ContractFactory::new(class_hash, account.clone());
+            let mut salt_buffer = [0u8; 32];
+            let mut rng = StdRng::from_entropy();
+            rng.fill_bytes(&mut salt_buffer[1..]);
+
+            factory
+                .deploy_v1(vec![], Felt::from_bytes_be(&salt_buffer), true)
+                .max_fee(Felt::from_dec_str("100000000000000000").unwrap())
+                .send()
+                .await
+                .unwrap()
+        }
+        Err(e) => {
+            info!("Could not deploy the contract {}", e);
+            return Err(e);
+        }
+    };
+
+    let receipt = account
+        .provider()
+        .get_transaction_receipt(hash.transaction_hash)
+        .await
+        .unwrap();
+
+    let receipt = match receipt {
+        TxnReceipt::Deploy(receipt) => receipt,
+        _ => {
+            info!("Unexpected response type TxnReceipt");
+            Err(RpcError::CallError(CallError::UnexpectedReceiptType))?
+        }
+    };
+
+    match receipt.common_receipt_properties.execution_status {
+        TxnExecutionStatus::Succeeded => {}
+        _ => Err(RpcError::CallError(CallError::UnexpectedExecutionResult))?,
+    }
+
+    let call = Call {
+        to: receipt.contract_address,
+        selector: get_selector_from_name("increase_balance").unwrap(),
+        calldata: vec![Felt::from_hex_unchecked("0x50")],
+    };
+
+    let result = account.execute_v1(vec![call]).send().await.unwrap();
+
+    Ok(result)
+}
+
+pub async fn invoke_contract_v3(
+    url: Url,
+    sierra_path: &str,
+    casm_path: &str,
+) -> Result<AddInvokeTransactionResult, RpcError> {
+    let (flattened_sierra_class, compiled_class_hash) =
+        get_compiled_contract(sierra_path, casm_path).await.unwrap();
+
+    let provider = JsonRpcClient::new(HttpTransport::new(url.clone()));
+    let create_acc_data =
+        match create_account(&provider, AccountType::Oz, Option::None, Option::None).await {
+            Ok(value) => value,
+            Err(e) => {
+                warn!("{}", "Could not create an account");
+                return Err(e.into());
+            }
+        };
+
+    match mint_2(
+        url.clone(),
+        &MintRequest2 {
+            amount: u128::MAX,
+            address: create_acc_data.address,
+            unit: PriceUnit::Fri,
+        },
+    )
+    .await
+    {
+        Ok(_) => {}
+        Err(e) => {
+            info!("{}", "Could not mint tokens");
+            return Err(e.into());
+        }
+    };
+
+    match mint_2(
+        url.clone(),
+        &MintRequest2 {
+            amount: u128::MAX,
+            address: create_acc_data.address,
+            unit: PriceUnit::Wei,
+        },
+    )
+    .await
+    {
+        Ok(_) => {}
+        Err(e) => {
+            info!("{}", "Could not mint tokens");
+            return Err(e.into());
+        }
+    };
+
+    let wait_conifg = WaitForTx {
+        wait: true,
+        wait_params: ValidatedWaitParams::default(),
+    };
+
+    let chain_id = get_chain_id(&provider).await.unwrap();
+
+    match deploy_account_v3(&provider, chain_id, wait_conifg, create_acc_data).await {
+        Ok(value) => Some(value),
+        Err(e) => {
+            info!("{}", "Could not deploy an account");
+            return Err(e.into());
+        }
+    };
+    let sender_address = create_acc_data.address;
+    let signer: LocalWallet = LocalWallet::from(create_acc_data.signing_key);
+
+    let mut account = SingleOwnerAccount::new(
+        JsonRpcClient::new(HttpTransport::new(url.clone())),
+        signer,
+        sender_address,
+        chain_id,
+        ExecutionEncoding::New,
+    );
+
+    account.set_block_id(BlockId::Tag(BlockTag::Latest));
+
+    let hash = match account
+        .declare_v3(Arc::new(flattened_sierra_class), compiled_class_hash)
+        .send()
+        .await
+    {
+        Ok(result) => Ok(result.class_hash),
+        Err(AccountError::Signing(sign_error)) => {
+            if sign_error.to_string().contains("is already declared") {
+                Ok(parse_class_hash_from_error(&sign_error.to_string()))
+            } else {
+                Err(RpcError::RunnerError(RunnerError::AccountFailure(format!(
+                    "Transaction execution error: {}",
+                    sign_error
+                ))))
+            }
+        }
+
+        Err(AccountError::Provider(ProviderError::Other(starkneterror))) => {
+            if starkneterror.to_string().contains("is already declared") {
+                Ok(parse_class_hash_from_error(&starkneterror.to_string()))
+            } else {
+                Err(RpcError::RunnerError(RunnerError::AccountFailure(format!(
+                    "Transaction execution error: {}",
+                    starkneterror
+                ))))
+            }
+        }
+
+        Err(e) => {
+            info!("General account error encountered: {:?}, possible cause - incorrect address or public_key in environment variables!", e);
+            Err(RpcError::RunnerError(RunnerError::AccountFailure(format!(
+                "Account error: {}",
+                e
+            ))))
+        }
+    };
+    let hash = match hash {
+        Ok(class_hash) => {
+            let factory = ContractFactory::new(class_hash, account.clone());
+            let mut salt_buffer = [0u8; 32];
+            let mut rng = StdRng::from_entropy();
+            rng.fill_bytes(&mut salt_buffer[1..]);
+
+            factory
+                .deploy_v1(vec![], Felt::from_bytes_be(&salt_buffer), true)
+                .max_fee(Felt::from_dec_str("100000000000000000").unwrap())
+                .send()
+                .await
+                .unwrap()
+        }
+        Err(e) => {
+            info!("Could not deploy the contract {}", e);
+            return Err(e);
+        }
+    };
+
+    let receipt = account
+        .provider()
+        .get_transaction_receipt(hash.transaction_hash)
+        .await
+        .unwrap();
+
+    let receipt = match receipt {
+        TxnReceipt::Deploy(receipt) => receipt,
+        _ => {
+            info!("Unexpected response type TxnReceipt");
+            Err(RpcError::CallError(CallError::UnexpectedReceiptType))?
+        }
+    };
+
+    match receipt.common_receipt_properties.execution_status {
+        TxnExecutionStatus::Succeeded => {}
+        _ => Err(RpcError::CallError(CallError::UnexpectedExecutionResult))?,
+    }
+
+    let call = Call {
+        to: receipt.contract_address,
+        selector: get_selector_from_name("increase_balance").unwrap(),
+        calldata: vec![Felt::from_hex_unchecked("0x50")],
+    };
+
+    let result = account.execute_v3(vec![call]).send().await.unwrap();
+
+    Ok(result)
 }
 
 pub async fn block_number(url: Url) -> Result<u64, RpcError> {

--- a/checker/src/v6/rpc/endpoints/mod.rs
+++ b/checker/src/v6/rpc/endpoints/mod.rs
@@ -12,7 +12,8 @@ use endpoints_functions::{
     get_class_at, get_class_hash_at, get_state_update, get_storage_at,
     get_transaction_by_block_id_and_index, get_transaction_by_hash_deploy_acc,
     get_transaction_by_hash_invoke, get_transaction_by_hash_non_existent_tx,
-    get_transaction_receipt, get_transaction_status_succeeded,
+    get_transaction_receipt, get_transaction_status_succeeded, invoke_contract_v1,
+    invoke_contract_v3,
 };
 use errors::RpcError;
 use starknet_types_core::felt::Felt;
@@ -55,6 +56,18 @@ pub trait RpcEndpoints {
     ) -> Result<AddInvokeTransactionResult, RpcError>;
 
     async fn add_invoke_transaction_v3(
+        &self,
+        sierra_path: &str,
+        casm_path: &str,
+    ) -> Result<AddInvokeTransactionResult, RpcError>;
+
+    async fn invoke_contract_v1(
+        &self,
+        sierra_path: &str,
+        casm_path: &str,
+    ) -> Result<AddInvokeTransactionResult, RpcError>;
+
+    async fn invoke_contract_v3(
         &self,
         sierra_path: &str,
         casm_path: &str,
@@ -174,6 +187,22 @@ impl RpcEndpoints for Rpc {
         casm_path: &str,
     ) -> Result<AddInvokeTransactionResult, RpcError> {
         add_invoke_transaction_v3(self.url.clone(), sierra_path, casm_path).await
+    }
+
+    async fn invoke_contract_v1(
+        &self,
+        sierra_path: &str,
+        casm_path: &str,
+    ) -> Result<AddInvokeTransactionResult, RpcError> {
+        invoke_contract_v1(self.url.clone(), sierra_path, casm_path).await
+    }
+
+    async fn invoke_contract_v3(
+        &self,
+        sierra_path: &str,
+        casm_path: &str,
+    ) -> Result<AddInvokeTransactionResult, RpcError> {
+        invoke_contract_v3(self.url.clone(), sierra_path, casm_path).await
     }
 
     async fn block_number(&self, url: Url) -> Result<u64, RpcError> {
@@ -366,6 +395,40 @@ pub async fn test_rpc_endpoints_v0_0_6(
         Err(e) => error!(
             "{} {} {}",
             "✗ Rpc add_invoke_transaction V3 INCOMPATIBLE:".red(),
+            e.to_string().red(),
+            "✗".red()
+        ),
+    }
+
+    restart_devnet(url.clone()).await?;
+    match rpc.invoke_contract_v1(sierra_path, casm_path).await {
+        Ok(_) => {
+            info!(
+                "{} {}",
+                "✓ Rpc invoke_contract V1 COMPATIBLE".green(),
+                "✓".green()
+            )
+        }
+        Err(e) => error!(
+            "{} {} {}",
+            "✗ Rpc invoke_contract V1 INCOMPATIBLE:".red(),
+            e.to_string().red(),
+            "✗".red()
+        ),
+    }
+
+    restart_devnet(url.clone()).await?;
+    match rpc.invoke_contract_v3(sierra_path, casm_path).await {
+        Ok(_) => {
+            info!(
+                "{} {}",
+                "✓ Rpc invoke_contract V3 COMPATIBLE".green(),
+                "✓".green()
+            )
+        }
+        Err(e) => error!(
+            "{} {} {}",
+            "✗ Rpc invoke_contract V3 INCOMPATIBLE:".red(),
             e.to_string().red(),
             "✗".red()
         ),

--- a/checker/src/v7/rpc/accounts/single_owner.rs
+++ b/checker/src/v7/rpc/accounts/single_owner.rs
@@ -101,9 +101,9 @@ where
     async fn sign_execution_v1(
         &self,
         execution: &RawExecutionV1,
-        query_only: bool,
+        _query_only: bool,
     ) -> Result<Vec<Felt>, Self::SignError> {
-        let tx_hash = execution.transaction_hash(self.chain_id, self.address, query_only, self);
+        let tx_hash = execution.transaction_hash(self.chain_id, self.address, false, self);
         let signature = self
             .signer
             .sign_hash(&tx_hash)

--- a/checker/src/v7/rpc/endpoints/endpoints_functions.rs
+++ b/checker/src/v7/rpc/endpoints/endpoints_functions.rs
@@ -20,6 +20,7 @@ use url::Url;
 use crate::v7::rpc::{
     accounts::{
         account::{Account, AccountError, ConnectedAccount},
+        call::Call,
         creation::{
             create::{create_account, AccountType},
             helpers::get_chain_id,
@@ -548,6 +549,329 @@ pub async fn add_invoke_transaction_v3(
             Err(e)
         }
     }
+}
+
+pub async fn invoke_contract_v1(
+    url: Url,
+    sierra_path: &str,
+    casm_path: &str,
+) -> Result<AddInvokeTransactionResult<Felt>, RpcError> {
+    let provider = JsonRpcClient::new(HttpTransport::new(url.clone()));
+
+    let create_acc_data =
+        match create_account(&provider, AccountType::Oz, Option::None, Option::None).await {
+            Ok(value) => value,
+            Err(e) => {
+                info!("{}", "Could not create an account");
+                return Err(e.into());
+            }
+        };
+
+    match mint(
+        url.clone(),
+        &MintRequest2 {
+            amount: u128::MAX,
+            address: create_acc_data.address,
+            unit: PriceUnit::Fri,
+        },
+    )
+    .await
+    {
+        Ok(_) => {}
+        Err(e) => {
+            info!("{}", "Could not mint tokens");
+            return Err(e.into());
+        }
+    };
+
+    match mint(
+        url.clone(),
+        &MintRequest2 {
+            amount: u128::MAX,
+            address: create_acc_data.address,
+            unit: PriceUnit::Wei,
+        },
+    )
+    .await
+    {
+        Ok(_) => {}
+        Err(e) => {
+            info!("{}", "Could not mint tokens");
+            return Err(e.into());
+        }
+    };
+
+    let wait_conifg = WaitForTx {
+        wait: true,
+        wait_params: ValidatedWaitParams::default(),
+    };
+
+    let chain_id = get_chain_id(&provider).await.unwrap();
+
+    match deploy_account(&provider, chain_id, wait_conifg, create_acc_data).await {
+        Ok(value) => Some(value),
+        Err(e) => {
+            info!("{}", "Could not deploy an account");
+            return Err(e.into());
+        }
+    };
+
+    let sender_address = create_acc_data.address;
+    let signer: LocalWallet = LocalWallet::from(create_acc_data.signing_key);
+
+    let mut account = SingleOwnerAccount::new(
+        provider.clone(),
+        signer,
+        sender_address,
+        chain_id,
+        ExecutionEncoding::New,
+    );
+
+    account.set_block_id(BlockId::Tag(BlockTag::Latest));
+
+    let (flattened_sierra_class, compiled_class_hash) =
+        get_compiled_contract(sierra_path, casm_path).await.unwrap();
+
+    let hash = match account
+        .declare_v2(Arc::new(flattened_sierra_class), compiled_class_hash)
+        .send()
+        .await
+    {
+        Ok(result) => Ok(result.class_hash),
+        Err(AccountError::Signing(sign_error)) => {
+            if sign_error.to_string().contains("is already declared") {
+                Ok(parse_class_hash_from_error(&sign_error.to_string()))
+            } else {
+                Err(RpcError::RunnerError(RunnerError::AccountFailure(format!(
+                    "Transaction execution error: {}",
+                    sign_error
+                ))))
+            }
+        }
+
+        Err(AccountError::Provider(ProviderError::Other(starkneterror))) => {
+            if starkneterror.to_string().contains("is already declared") {
+                Ok(parse_class_hash_from_error(&starkneterror.to_string()))
+            } else {
+                Err(RpcError::RunnerError(RunnerError::AccountFailure(format!(
+                    "Transaction execution error: {}",
+                    starkneterror
+                ))))
+            }
+        }
+        Err(e) => {
+            info!("General account error encountered: {:?}, possible cause - incorrect address or public_key in environment variables!", e);
+            Err(RpcError::RunnerError(RunnerError::AccountFailure(format!(
+                "Account error: {}",
+                e
+            ))))
+        }
+    };
+
+    let hash = match hash {
+        Ok(class_hash) => {
+            let factory = ContractFactory::new(class_hash, account.clone());
+            let mut salt_buffer = [0u8; 32];
+            let mut rng = StdRng::from_entropy();
+            rng.fill_bytes(&mut salt_buffer[1..]);
+
+            factory
+                .deploy_v1(vec![], Felt::from_bytes_be(&salt_buffer), true)
+                .max_fee(Felt::from_dec_str("100000000000000000").unwrap())
+                .send()
+                .await
+                .unwrap()
+        }
+        Err(e) => {
+            info!("Could not deploy the contract {}", e);
+            return Err(e);
+        }
+    };
+
+    let receipt = account
+        .provider()
+        .get_transaction_receipt(hash.transaction_hash)
+        .await
+        .unwrap();
+
+    let receipt = match receipt {
+        TxnReceipt::Deploy(receipt) => receipt,
+        _ => {
+            info!("Unexpected response type TxnReceipt");
+            Err(RpcError::CallError(CallError::UnexpectedReceiptType))?
+        }
+    };
+
+    let call = Call {
+        to: receipt.contract_address,
+        selector: get_selector_from_name("increase_balance").unwrap(),
+        calldata: vec![Felt::from_hex_unchecked("0x50")],
+    };
+
+    let result = account.execute_v1(vec![call]).send().await.unwrap();
+
+    Ok(result)
+}
+
+pub async fn invoke_contract_v3(
+    url: Url,
+    sierra_path: &str,
+    casm_path: &str,
+) -> Result<AddInvokeTransactionResult<Felt>, RpcError> {
+    let provider = JsonRpcClient::new(HttpTransport::new(url.clone()));
+
+    let create_acc_data =
+        match create_account(&provider, AccountType::Oz, Option::None, Option::None).await {
+            Ok(value) => value,
+            Err(e) => {
+                info!("{}", "Could not create an account");
+                return Err(e.into());
+            }
+        };
+
+    match mint(
+        url.clone(),
+        &MintRequest2 {
+            amount: u128::MAX,
+            address: create_acc_data.address,
+            unit: PriceUnit::Fri,
+        },
+    )
+    .await
+    {
+        Ok(_) => {}
+        Err(e) => {
+            info!("{}", "Could not mint tokens");
+            return Err(e.into());
+        }
+    };
+
+    match mint(
+        url.clone(),
+        &MintRequest2 {
+            amount: u128::MAX,
+            address: create_acc_data.address,
+            unit: PriceUnit::Wei,
+        },
+    )
+    .await
+    {
+        Ok(_) => {}
+        Err(e) => {
+            info!("{}", "Could not mint tokens");
+            return Err(e.into());
+        }
+    };
+
+    let wait_conifg = WaitForTx {
+        wait: true,
+        wait_params: ValidatedWaitParams::default(),
+    };
+
+    let chain_id = get_chain_id(&provider).await.unwrap();
+
+    match deploy_account(&provider, chain_id, wait_conifg, create_acc_data).await {
+        Ok(value) => Some(value),
+        Err(e) => {
+            info!("{}", "Could not deploy an account");
+            return Err(e.into());
+        }
+    };
+
+    let sender_address = create_acc_data.address;
+    let signer: LocalWallet = LocalWallet::from(create_acc_data.signing_key);
+
+    let mut account = SingleOwnerAccount::new(
+        provider.clone(),
+        signer,
+        sender_address,
+        chain_id,
+        ExecutionEncoding::New,
+    );
+
+    account.set_block_id(BlockId::Tag(BlockTag::Latest));
+
+    let (flattened_sierra_class, compiled_class_hash) =
+        get_compiled_contract(sierra_path, casm_path).await.unwrap();
+
+    let hash = match account
+        .declare_v3(flattened_sierra_class, compiled_class_hash)
+        .send()
+        .await
+    {
+        Ok(result) => Ok(result.class_hash),
+        Err(AccountError::Signing(sign_error)) => {
+            if sign_error.to_string().contains("is already declared") {
+                Ok(parse_class_hash_from_error(&sign_error.to_string()))
+            } else {
+                Err(RpcError::RunnerError(RunnerError::AccountFailure(format!(
+                    "Transaction execution error: {}",
+                    sign_error
+                ))))
+            }
+        }
+
+        Err(AccountError::Provider(ProviderError::Other(starkneterror))) => {
+            if starkneterror.to_string().contains("is already declared") {
+                Ok(parse_class_hash_from_error(&starkneterror.to_string()))
+            } else {
+                Err(RpcError::RunnerError(RunnerError::AccountFailure(format!(
+                    "Transaction execution error: {}",
+                    starkneterror
+                ))))
+            }
+        }
+        Err(e) => {
+            info!("General account error encountered: {:?}, possible cause - incorrect address or public_key in environment variables!", e);
+            Err(RpcError::RunnerError(RunnerError::AccountFailure(format!(
+                "Account error: {}",
+                e
+            ))))
+        }
+    };
+
+    let hash = match hash {
+        Ok(class_hash) => {
+            let factory = ContractFactory::new(class_hash, account.clone());
+            let mut salt_buffer = [0u8; 32];
+            let mut rng = StdRng::from_entropy();
+            rng.fill_bytes(&mut salt_buffer[1..]);
+
+            factory
+                .deploy_v3(vec![], Felt::from_bytes_be(&salt_buffer), true)
+                .send()
+                .await
+                .unwrap()
+        }
+        Err(e) => {
+            info!("Could not deploy the contract {}", e);
+            return Err(e);
+        }
+    };
+
+    let receipt = account
+        .provider()
+        .get_transaction_receipt(hash.transaction_hash)
+        .await
+        .unwrap();
+
+    let receipt = match receipt {
+        TxnReceipt::Deploy(receipt) => receipt,
+        _ => {
+            info!("Unexpected response type TxnReceipt");
+            Err(RpcError::CallError(CallError::UnexpectedReceiptType))?
+        }
+    };
+
+    let call = Call {
+        to: receipt.contract_address,
+        selector: get_selector_from_name("increase_balance").unwrap(),
+        calldata: vec![Felt::from_hex_unchecked("0x50")],
+    };
+
+    let result = account.execute_v3(vec![call]).send().await.unwrap();
+
+    Ok(result)
 }
 
 pub async fn block_number(url: Url) -> Result<u64, RpcError> {

--- a/checker/src/v7/rpc/endpoints/mod.rs
+++ b/checker/src/v7/rpc/endpoints/mod.rs
@@ -12,7 +12,8 @@ use endpoints_functions::{
     get_class_at, get_class_hash_at, get_state_update, get_storage_at,
     get_transaction_by_block_id_and_index, get_transaction_by_hash_deploy_acc,
     get_transaction_by_hash_invoke, get_transaction_by_hash_non_existent_tx,
-    get_transaction_receipt, get_transaction_status_succeeded,
+    get_transaction_receipt, get_transaction_status_succeeded, invoke_contract_v1,
+    invoke_contract_v3,
 };
 use errors::RpcError;
 use starknet_types_core::felt::Felt;
@@ -57,6 +58,20 @@ pub trait RpcEndpoints {
 
     async fn add_invoke_transaction_v3(
         &self,
+        sierra_path: &str,
+        casm_path: &str,
+    ) -> Result<AddInvokeTransactionResult<Felt>, RpcError>;
+
+    async fn invoke_contract_v1(
+        &self,
+        url: Url,
+        sierra_path: &str,
+        casm_path: &str,
+    ) -> Result<AddInvokeTransactionResult<Felt>, RpcError>;
+
+    async fn invoke_contract_v3(
+        &self,
+        url: Url,
         sierra_path: &str,
         casm_path: &str,
     ) -> Result<AddInvokeTransactionResult<Felt>, RpcError>;
@@ -176,6 +191,24 @@ impl RpcEndpoints for Rpc {
         casm_path: &str,
     ) -> Result<AddInvokeTransactionResult<Felt>, RpcError> {
         add_invoke_transaction_v3(self.url.clone(), sierra_path, casm_path).await
+    }
+
+    async fn invoke_contract_v1(
+        &self,
+        url: Url,
+        sierra_path: &str,
+        casm_path: &str,
+    ) -> Result<AddInvokeTransactionResult<Felt>, RpcError> {
+        invoke_contract_v1(url.clone(), sierra_path, casm_path).await
+    }
+
+    async fn invoke_contract_v3(
+        &self,
+        url: Url,
+        sierra_path: &str,
+        casm_path: &str,
+    ) -> Result<AddInvokeTransactionResult<Felt>, RpcError> {
+        invoke_contract_v3(url.clone(), sierra_path, casm_path).await
     }
 
     async fn block_number(&self, url: Url) -> Result<u64, RpcError> {
@@ -372,6 +405,48 @@ pub async fn test_rpc_endpoints_v0_0_7(
         Err(e) => error!(
             "{} {} {}",
             "✗ Rpc add_invoke_transaction V3 INCOMPATIBLE:".red(),
+            e.to_string().red(),
+            "✗".red()
+        ),
+    }
+
+    restart_devnet(url.clone()).await?;
+
+    match rpc
+        .invoke_contract_v1(url.clone(), sierra_path, casm_path)
+        .await
+    {
+        Ok(_) => {
+            info!(
+                "{} {}",
+                "✓ Rpc invoke_contract V1 COMPATIBLE".green(),
+                "✓".green()
+            )
+        }
+        Err(e) => error!(
+            "{} {} {}",
+            "✗ Rpc invoke_contract V1 INCOMPATIBLE:".red(),
+            e.to_string().red(),
+            "✗".red()
+        ),
+    }
+
+    restart_devnet(url.clone()).await?;
+
+    match rpc
+        .invoke_contract_v3(url.clone(), sierra_path, casm_path)
+        .await
+    {
+        Ok(_) => {
+            info!(
+                "{} {}",
+                "✓ Rpc invoke_contract V3 COMPATIBLE".green(),
+                "✓".green()
+            )
+        }
+        Err(e) => error!(
+            "{} {} {}",
+            "✗ Rpc invoke_contract V3 INCOMPATIBLE:".red(),
             e.to_string().red(),
             "✗".red()
         ),

--- a/contracts/src/lib.cairo
+++ b/contracts/src/lib.cairo
@@ -1,15 +1,7 @@
 #[starknet::interface]
 pub trait IHelloStarknet<TContractState> {
     fn increase_balance(ref self: TContractState, amount: felt252);
-    fn get_balance(self: @TContractState) -> BalanceResult;
-}
-
-#[derive(Debug, PartialEq, Serde, Drop)]
-pub enum BalanceResult {
-    Zero,
-    Positive,
-    Negative,
-    Overdrawn
+    fn get_balance(self: @TContractState) -> felt252;
 }
 
 #[starknet::contract]
@@ -41,26 +33,14 @@ mod HelloStarknet {
         self.emit(DepositFromL1 { user, amount });
     }
 
-    use super::BalanceResult;
-
-    
     #[abi(embed_v0)]
     impl HelloStarknetImpl of super::IHelloStarknet<ContractState> {
         fn increase_balance(ref self: ContractState, amount: felt252) {
             self.balance.write(self.balance.read() + amount);
         }
         
-        fn get_balance(self: @ContractState) -> BalanceResult {
-            let balance: u32 = self.balance.read().try_into().unwrap();
-
-            if balance > 0 {
-                BalanceResult::Positive
-            } else if balance < 0 {
-                BalanceResult::Negative
-            } else {
-                BalanceResult::Zero
-            }
+        fn get_balance(self: @ContractState) -> felt252 {
+            self.balance.read()
         }
-
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new asynchronous methods `invoke_contract`, `invoke_contract_v1`, and `invoke_contract_v3` for contract invocation via RPC.
	- Added `set_block_id` method to enhance mutability in `SingleOwnerAccount`.
- **Bug Fixes**
	- Simplified `sign_execution_v1` and `sign_execution_v3` methods by hardcoding parameters, improving transaction hash generation.
- **Documentation**
	- Updated tests to include new contract invocation methods and log results for compatibility checks. 
- **Chores**
	- Removed `BalanceResult` enum and simplified `get_balance` method for more straightforward balance retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->