### PR TITLE
Lock madara dockerfile to commit that fixes sync. Reduce replicas to 1.

### DIFF
--- a/k8s/base/juno/statefulset.yaml
+++ b/k8s/base/juno/statefulset.yaml
@@ -4,7 +4,7 @@ metadata:
   name: juno
 spec:
   serviceName: juno
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       app: juno

--- a/k8s/base/madara/madara.dockerfile
+++ b/k8s/base/madara/madara.dockerfile
@@ -15,6 +15,9 @@ WORKDIR /usr/src/
 RUN git clone https://github.com/madara-alliance/madara.git
 WORKDIR /usr/src/madara/
 
+# Checkout the specific commit
+RUN git checkout 166ec294d91e46d34419d224a94cadcfdfc5926e
+
 # Installing scarb
 ENV SCARB_VERSION="v2.8.2"
 ENV SCARB_REPO="https://github.com/software-mansion/scarb/releases/download"
@@ -45,7 +48,7 @@ WORKDIR /usr/local/bin
 # Copy the compiled binary from the builder stage
 COPY --from=builder /usr/src/madara/target/release/madara .
 
-# chain presets to be monted at startup
+# chain presets to be mounted at startup
 VOLUME /usr/local/bin/crates/primitives/chain_config/presets
 VOLUME /usr/local/bin/crates/primitives/chain_config/resources
 

--- a/k8s/base/madara/statefulset.yaml
+++ b/k8s/base/madara/statefulset.yaml
@@ -4,7 +4,7 @@ metadata:
   name: madara
 spec:
   serviceName: madara
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       app: madara
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: madara
-          image: docker.io/uacias/madara:latest
+          image: docker.io/uacias/madara:v1.0.0
           envFrom:
             - secretRef:
                 name: secret

--- a/k8s/base/papyrus/statefulset.yaml
+++ b/k8s/base/papyrus/statefulset.yaml
@@ -4,7 +4,7 @@ metadata:
   name: papyrus
 spec:
   serviceName: papyrus
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       app: papyrus

--- a/k8s/base/pathfinder/statefulset.yaml
+++ b/k8s/base/pathfinder/statefulset.yaml
@@ -4,7 +4,7 @@ metadata:
   name: pathfinder
 spec:
   serviceName: pathfinder
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       app: pathfinder


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Reduced the number of pod replicas for the `juno`, `madara`, `papyrus`, and `pathfinder` applications from 2 to 1, optimizing resource usage.
	- Updated the container image version for the `madara` application to a specific version `v1.0.0` for improved stability.

- **Bug Fixes**
	- Corrected a comment in the `madara` Dockerfile for clarity regarding the mounting of chain presets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->