### PR TITLE
Add waiting for jobs to be finished.

### DIFF
--- a/k8s/base/juno/statefulset.yaml
+++ b/k8s/base/juno/statefulset.yaml
@@ -22,7 +22,7 @@ spec:
               echo "Waiting for data to be copied by juno-setup job..." && \
               while [ ! -d /mnt/data/juno/juno-sepolia ]; do \
                 echo "Waiting for /mnt/data/juno/juno-sepolia to be available..."; \
-                sleep 10; \
+                sleep 5; \
               done; \
               echo "Data is available, starting copying..." && \
               cp -r /mnt/data/juno/juno-sepolia /var/lib/juno

--- a/k8s/base/juno/statefulset.yaml
+++ b/k8s/base/juno/statefulset.yaml
@@ -19,7 +19,12 @@ spec:
           command: ["/bin/sh", "-c"]
           args:
             - |
-              echo "Copying data for juno instance $(hostname)..." && \
+              echo "Waiting for data to be copied by juno-setup job..." && \
+              while [ ! -d /mnt/data/juno/juno-sepolia ]; do \
+                echo "Waiting for /mnt/data/juno/juno-sepolia to be available..."; \
+                sleep 10; \
+              done; \
+              echo "Data is available, starting copying..." && \
               cp -r /mnt/data/juno/juno-sepolia /var/lib/juno
           volumeMounts:
             - name: juno-setup

--- a/k8s/base/pathfinder/statefulset.yaml
+++ b/k8s/base/pathfinder/statefulset.yaml
@@ -26,7 +26,7 @@ spec:
               echo "Waiting for data to be copied by pathfinder-setup job..." && \
               while [ ! -f /mnt/data/pathfinder/testnet-sepolia.sqlite ]; do \
                 echo "Waiting for /mnt/data/pathfinder/testnet-sepolia.sqlite to be available..."; \
-                sleep 10; \
+                sleep 5; \
               done; \
               echo "Data is available, starting copying..." && \
               cp /mnt/data/pathfinder/testnet-sepolia.sqlite /usr/share/pathfinder/data/testnet-sepolia.sqlite

--- a/k8s/base/pathfinder/statefulset.yaml
+++ b/k8s/base/pathfinder/statefulset.yaml
@@ -23,7 +23,12 @@ spec:
           command: ["/bin/sh", "-c"]
           args:
             - |
-              echo "Copying data for pathfinder instance $(hostname)..." && \
+              echo "Waiting for data to be copied by pathfinder-setup job..." && \
+              while [ ! -f /mnt/data/pathfinder/testnet-sepolia.sqlite ]; do \
+                echo "Waiting for /mnt/data/pathfinder/testnet-sepolia.sqlite to be available..."; \
+                sleep 10; \
+              done; \
+              echo "Data is available, starting copying..." && \
               cp /mnt/data/pathfinder/testnet-sepolia.sqlite /usr/share/pathfinder/data/testnet-sepolia.sqlite
           volumeMounts:
             - name: pathfinder-setup


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced initialization for the `juno` application to wait for a specific directory before data copying.
	- Improved initialization for the `pathfinder` application to wait for a specific file before proceeding with the copy operation.

- **Bug Fixes**
	- Increased robustness of the setup process by ensuring necessary data is available before initialization tasks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->