### PR TITLE
Katana no fee and no account validation suites

### DIFF
--- a/openrpc-testgen-runner/Cargo.toml
+++ b/openrpc-testgen-runner/Cargo.toml
@@ -14,9 +14,13 @@ openrpc-testgen = { path = "../openrpc-testgen", features = [
   "openrpc",
   "katana",
   "katana_no_mining",
+  "katana_no_fee",
+  "katana_no_account_validation",
 ] }
 
 [features]
 katana = []
+katana_no_fee = []
 katana_no_mining = []
+katana_no_account_validation = []
 openrpc = []

--- a/openrpc-testgen-runner/src/args.rs
+++ b/openrpc-testgen-runner/src/args.rs
@@ -24,4 +24,14 @@ pub struct Args {
 
     #[arg(long, env, help = "Class hash of account contract")]
     pub account_class_hash: Felt,
+
+    #[arg(short, long, value_enum)]
+    pub suite: Vec<Suite>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, clap::ValueEnum)]
+pub enum Suite {
+    OpenRpc,
+    Katana,
+    KatanaNoMining,
 }

--- a/openrpc-testgen-runner/src/main.rs
+++ b/openrpc-testgen-runner/src/main.rs
@@ -3,6 +3,10 @@ use clap::Parser;
 #[allow(unused_imports)]
 use openrpc_testgen::{
     suite_katana::{SetupInput as SetupInputKatana, TestSuiteKatana},
+    suite_katana_no_account_validation::{
+        SetupInput as SetupInputKatanaNoAccountValidation, TestSuiteKatanaNoAccountValidation,
+    },
+    suite_katana_no_fee::{SetupInput as SetupInputKatanaNoFee, TestSuiteKatanaNoFee},
     suite_katana_no_mining::{SetupInput as SetupInputKatanaNoMining, TestSuiteKatanaNoMining},
     suite_openrpc::{SetupInput, TestSuiteOpenRpc},
     RunnableTrait,
@@ -53,5 +57,29 @@ async fn main() {
         };
 
         let _ = TestSuiteKatanaNoMining::run(&suite_katana_input).await;
+    }
+    #[cfg(feature = "katana_no_fee")]
+    {
+        let suite_katana_input = SetupInputKatanaNoFee {
+            urls: args.urls.clone(),
+            paymaster_account_address: args.paymaster_account_address,
+            paymaster_private_key: args.paymaster_private_key,
+            udc_address: args.udc_address,
+            account_class_hash: args.account_class_hash,
+        };
+
+        let _ = TestSuiteKatanaNoFee::run(&suite_katana_input).await;
+    }
+    #[cfg(feature = "katana_no_account_validation")]
+    {
+        let suite_katana_input = SetupInputKatanaNoAccountValidation {
+            urls: args.urls.clone(),
+            paymaster_account_address: args.paymaster_account_address,
+            paymaster_private_key: args.paymaster_private_key,
+            udc_address: args.udc_address,
+            account_class_hash: args.account_class_hash,
+        };
+
+        let _ = TestSuiteKatanaNoAccountValidation::run(&suite_katana_input).await;
     }
 }

--- a/openrpc-testgen/Cargo.toml
+++ b/openrpc-testgen/Cargo.toml
@@ -39,5 +39,7 @@ url.workspace = true
 no_unknown_fields = []
 rust-analyzer = []
 katana = []
+katana_no_fee = []
+katana_no_account_validation = []
 katana_no_mining = []
 openrpc = []

--- a/openrpc-testgen/src/lib.rs
+++ b/openrpc-testgen/src/lib.rs
@@ -9,6 +9,10 @@ use utils::v7::{
 pub mod macros;
 #[cfg(feature = "katana")]
 pub mod suite_katana;
+#[cfg(feature = "katana_no_account_validation")]
+pub mod suite_katana_no_account_validation;
+#[cfg(feature = "katana_no_fee")]
+pub mod suite_katana_no_fee;
 #[cfg(feature = "katana_no_mining")]
 pub mod suite_katana_no_mining;
 #[cfg(feature = "openrpc")]

--- a/openrpc-testgen/src/suite_katana/mod.rs
+++ b/openrpc-testgen/src/suite_katana/mod.rs
@@ -40,12 +40,10 @@ use crate::{
     RandomizableAccountsTrait, SetupableTrait,
 };
 
-pub mod test_declaring_already_existing_class;
-// pub mod test_get_blocks_from_hash;
-// pub mod test_get_blocks_from_num;
-
 pub mod test_concurrent_transactions_submissions;
 pub mod test_declare_and_deploy_contract;
+pub mod test_declaring_already_existing_class;
+pub mod test_deploy_accout;
 pub mod test_ensure_validator_have_valid_state;
 pub mod test_estimate_fee;
 pub mod test_send_txs_with_insufficient_fee;

--- a/openrpc-testgen/src/suite_katana/test_deploy_accout.rs
+++ b/openrpc-testgen/src/suite_katana/test_deploy_accout.rs
@@ -1,0 +1,93 @@
+use crate::{
+    assert_eq_result, assert_matches_result,
+    utils::v7::{
+        accounts::{
+            account::{Account, ConnectedAccount},
+            call::Call,
+            deployment::helpers::get_contract_address,
+            factory::{open_zeppelin::OpenZeppelinAccountFactory, AccountFactory},
+        },
+        endpoints::{
+            errors::OpenRpcTestGenError,
+            utils::{get_selector_from_name, wait_for_sent_transaction},
+        },
+        providers::provider::Provider,
+        signers::{key_pair::SigningKey, local_wallet::LocalWallet, signer::Signer},
+    },
+    RandomizableAccountsTrait, RunnableTrait,
+};
+use starknet_types_core::felt::Felt;
+use starknet_types_rpc::{BlockId, BlockTag, DeployAccountTxnReceipt, TxnReceipt};
+
+const DEFAULT_ACCOUNT_CLASS_HASH: Felt =
+    Felt::from_hex_unchecked("0x07dc7899aa655b0aae51eadff6d801a58e97dd99cf4666ee59e704249e51adf2");
+
+#[derive(Clone, Debug)]
+pub struct TestCase {}
+
+impl RunnableTrait for TestCase {
+    type Input = super::TestSuiteKatana;
+    async fn run(test_input: &Self::Input) -> Result<Self, OpenRpcTestGenError> {
+        let funding_account = test_input.random_paymaster_account.random_accounts()?;
+
+        let provider = test_input
+            .random_paymaster_account
+            .random_accounts()?
+            .provider()
+            .clone();
+        let chain_id = provider.chain_id().await?;
+
+        // Precompute the contract address of the new account with the given parameters:
+        let signer = LocalWallet::from(SigningKey::from_random());
+        let class_hash = DEFAULT_ACCOUNT_CLASS_HASH;
+        let salt = Felt::from_hex_unchecked("0x123");
+        let ctor_args = [signer.get_public_key().await?.scalar()];
+        let computed_address = get_contract_address(salt, class_hash, &ctor_args, Felt::ZERO);
+
+        // send enough tokens to the new_account's address just to send the deploy account tx
+        let amount = Felt::from_hex_unchecked("0x1ba32524a30000");
+        let recipient = computed_address;
+
+        let transfer_execution = funding_account
+            .execute_v1(vec![Call {
+                to: Felt::from_hex(
+                    "0x49D36570D4E46F48E99674BD3FCC84644DDD6B96F7C741B1562B82F9E004DC7",
+                )?,
+                selector: get_selector_from_name("transfer")?,
+                calldata: vec![recipient, amount, Felt::ZERO],
+            }])
+            .send()
+            .await?;
+
+        wait_for_sent_transaction(transfer_execution.transaction_hash, &funding_account).await?;
+
+        let factory =
+            OpenZeppelinAccountFactory::new(class_hash, chain_id, &signer, &provider).await?;
+        let res = factory.deploy_v1(salt).send().await?;
+        // the contract address in the send tx result must be the same as the computed one
+        assert_eq_result!(res.contract_address, computed_address);
+
+        wait_for_sent_transaction(res.transaction_hash, &funding_account).await?;
+
+        let receipt = provider
+            .get_transaction_receipt(res.transaction_hash)
+            .await?;
+
+        assert_matches_result!(
+            receipt,
+            TxnReceipt::DeployAccount(DeployAccountTxnReceipt { contract_address, .. })  => {
+                // the contract address in the receipt must be the same as the computed one
+                assert_eq_result!(contract_address, computed_address)
+            }
+        );
+
+        // Verify the `getClassHashAt` returns the same class hash that we use for the account
+        // deployment
+        let res = provider
+            .get_class_hash_at(BlockId::Tag(BlockTag::Pending), computed_address)
+            .await?;
+        assert_eq_result!(res, class_hash);
+
+        Ok(Self {})
+    }
+}

--- a/openrpc-testgen/src/suite_katana/test_send_txs_with_insufficient_fee.rs
+++ b/openrpc-testgen/src/suite_katana/test_send_txs_with_insufficient_fee.rs
@@ -31,8 +31,11 @@ impl RunnableTrait for TestCase {
             calldata: vec![Felt::from_hex("0x50")?],
         };
 
+        // -----------------------------------------------------------------------
+        //  transaction with low max fee (underpriced).
+
         let res = account
-            .execute_v1(vec![increase_balance_call])
+            .execute_v1(vec![increase_balance_call.clone()])
             .max_fee(Felt::TWO)
             .send()
             .await;
@@ -50,6 +53,30 @@ impl RunnableTrait for TestCase {
             "Nonce shouldn't change in fee-enabled mode"
         );
 
+        // -----------------------------------------------------------------------
+        //  transaction with insufficient balance.
+
+        let fee = Felt::from(DEFAULT_PREFUNDED_ACCOUNT_BALANCE + 1);
+
+        let res = account
+            .execute_v1(vec![increase_balance_call])
+            .max_fee(fee)
+            .send()
+            .await;
+
+        assert_matches_result!(
+            res.unwrap_err(),
+            AccountError::Provider(ProviderError::StarknetError(
+                StarknetError::InsufficientAccountBalance
+            ))
+        );
+        // nonce shouldn't change for an invalid tx.
+        let nonce = account.get_nonce().await?;
+        assert_eq_result!(
+            nonce,
+            initial_nonce,
+            "Nonce shouldn't change in fee-enabled mode"
+        );
         Ok(Self {})
     }
 }

--- a/openrpc-testgen/src/suite_katana/test_send_txs_with_invalid_signature.rs
+++ b/openrpc-testgen/src/suite_katana/test_send_txs_with_invalid_signature.rs
@@ -29,14 +29,14 @@ impl RunnableTrait for TestCase {
         let chain_id = get_chain_id(&provider).await?;
 
         let account_invalid = SingleOwnerAccount::new(
-            account.provider(),
+            account.provider().clone(),
             LocalWallet::from(SigningKey::from_random()),
             account.address(),
             chain_id,
             ExecutionEncoding::New,
         );
         // initial sender's account nonce. use to assert how the txs validity change the account nonce.
-        let initial_nonce = account.get_nonce().await?;
+        let initial_nonce = account_invalid.get_nonce().await?;
 
         let increase_balance_call = Call {
             to: test_input.deployed_contract_address,
@@ -60,7 +60,9 @@ impl RunnableTrait for TestCase {
                 StarknetError::ValidationFailure(_)
             ))
         );
-        let nonce = account.get_nonce().await?;
+
+        // nonce shouldn't change for an invalid tx.
+        let nonce = account_invalid.get_nonce().await?;
         assert_eq_result!(nonce, initial_nonce);
 
         Ok(Self {})

--- a/openrpc-testgen/src/suite_katana_no_account_validation/mod.rs
+++ b/openrpc-testgen/src/suite_katana_no_account_validation/mod.rs
@@ -1,0 +1,597 @@
+use core::fmt;
+use std::{path::PathBuf, str::FromStr, time::Duration};
+
+use rand::{rngs::StdRng, RngCore, SeedableRng};
+use starknet_types_core::felt::Felt;
+use starknet_types_rpc::{
+    BlockId, BlockTag, ClassAndTxnHash, DeclareTxn, EventFilterWithPageRequest, Txn,
+    TxnExecutionStatus, TxnFinalityAndExecutionStatus, TxnReceipt, TxnStatus,
+};
+use tracing::info;
+use url::Url;
+
+use crate::{
+    utils::{
+        random_single_owner_account::RandomSingleOwnerAccount,
+        v7::{
+            accounts::{
+                account::{Account, AccountError, ConnectedAccount},
+                call::Call,
+                creation::{
+                    create::{create_account, AccountType},
+                    helpers::get_chain_id,
+                },
+                single_owner::{ExecutionEncoding, SingleOwnerAccount},
+            },
+            contract::factory::ContractFactory,
+            endpoints::{
+                declare_contract::{
+                    extract_class_hash_from_error, get_compiled_contract,
+                    parse_class_hash_from_error, RunnerError,
+                },
+                errors::{CallError, ContinuationTokenError, OpenRpcTestGenError},
+                utils::get_selector_from_name,
+            },
+            providers::{
+                jsonrpc::{HttpTransport, JsonRpcClient},
+                provider::{Provider, ProviderError},
+            },
+            signers::{key_pair::SigningKey, local_wallet::LocalWallet},
+        },
+    },
+    RandomizableAccountsTrait, SetupableTrait,
+};
+
+pub mod test_send_txs_with_invalid_signature;
+
+#[derive(Clone, Debug)]
+pub struct TestSuiteKatanaNoAccountValidation {
+    pub random_paymaster_account: RandomSingleOwnerAccount,
+    pub paymaster_private_key: Felt,
+    pub random_executable_account: RandomSingleOwnerAccount,
+    pub account_class_hash: Felt,
+    pub udc_address: Felt,
+    pub deployed_contract_address: Felt,
+    pub dev_client: DevClient,
+}
+
+#[derive(Clone, Debug)]
+pub struct SetupInput {
+    pub urls: Vec<Url>,
+    pub paymaster_account_address: Felt,
+    pub paymaster_private_key: Felt,
+    pub account_class_hash: Felt,
+    pub udc_address: Felt,
+}
+
+impl SetupableTrait for TestSuiteKatanaNoAccountValidation {
+    type Input = SetupInput;
+
+    async fn setup(setup_input: &Self::Input) -> Result<Self, OpenRpcTestGenError> {
+        let (executable_account_flattened_sierra_class, executable_account_compiled_class_hash) =
+            get_compiled_contract(
+                PathBuf::from_str("target/dev/contracts_ExecutableAccount.contract_class.json")?,
+                PathBuf::from_str(
+                    "target/dev/contracts_ExecutableAccount.compiled_contract_class.json",
+                )?,
+            )
+            .await
+            .unwrap();
+
+        let dev_client = DevClient::new(setup_input.urls[0].clone());
+
+        let provider = JsonRpcClient::new(HttpTransport::new(setup_input.urls[0].clone()));
+        let chain_id = get_chain_id(&provider).await?;
+
+        let paymaster_private_key =
+            SigningKey::from_secret_scalar(setup_input.paymaster_private_key);
+
+        let mut paymaster_account = SingleOwnerAccount::new(
+            provider.clone(),
+            LocalWallet::from(paymaster_private_key),
+            setup_input.paymaster_account_address,
+            chain_id,
+            ExecutionEncoding::New,
+        );
+
+        paymaster_account.set_block_id(BlockId::Tag(BlockTag::Pending));
+
+        let declare_executable_account_hash = match paymaster_account
+            .declare_v3(
+                executable_account_flattened_sierra_class.clone(),
+                executable_account_compiled_class_hash,
+            )
+            .send()
+            .await
+        {
+            Ok(result) => {
+                wait_for_sent_transaction_katana(result.transaction_hash, &paymaster_account)
+                    .await?;
+                dev_client.generate_block().await?;
+                Ok(result.class_hash)
+            }
+            Err(AccountError::Signing(sign_error)) => {
+                if sign_error.to_string().contains("is already declared") {
+                    Ok(parse_class_hash_from_error(&sign_error.to_string())?)
+                } else {
+                    Err(OpenRpcTestGenError::RunnerError(
+                        RunnerError::AccountFailure(format!(
+                            "Transaction execution error: {}",
+                            sign_error
+                        )),
+                    ))
+                }
+            }
+
+            Err(AccountError::Provider(ProviderError::Other(starkneterror))) => {
+                if starkneterror.to_string().contains("is already declared") {
+                    Ok(parse_class_hash_from_error(&starkneterror.to_string())?)
+                } else {
+                    Err(OpenRpcTestGenError::RunnerError(
+                        RunnerError::AccountFailure(format!(
+                            "Transaction execution error: {}",
+                            starkneterror
+                        )),
+                    ))
+                }
+            }
+            Err(e) => {
+                let full_error_message = format!("{:?}", e);
+                if full_error_message.contains("is already declared") {
+                    Ok(extract_class_hash_from_error(&full_error_message)?)
+                } else {
+                    Err(OpenRpcTestGenError::AccountError(AccountError::Other(
+                        full_error_message,
+                    )))
+                }
+            }
+        }?;
+
+        let executable_account_data = create_account(
+            &provider,
+            AccountType::Oz,
+            Option::None,
+            Some(declare_executable_account_hash),
+        )
+        .await?;
+
+        let deploy_executable_account_call: Call = Call {
+            to: setup_input.udc_address,
+            selector: get_selector_from_name("deployContract")?,
+            calldata: vec![
+                declare_executable_account_hash,
+                executable_account_data.salt,
+                Felt::ZERO,
+                Felt::ONE,
+                SigningKey::verifying_key(&executable_account_data.signing_key).scalar(),
+            ],
+        };
+
+        let deploy_executable_account_result = paymaster_account
+            .execute_v3(vec![deploy_executable_account_call])
+            .send()
+            .await?;
+
+        wait_for_sent_transaction_katana(
+            deploy_executable_account_result.transaction_hash,
+            &paymaster_account,
+        )
+        .await?;
+
+        dev_client.generate_block().await?;
+
+        let mut executable_account = SingleOwnerAccount::new(
+            provider.clone(),
+            LocalWallet::from(executable_account_data.signing_key),
+            executable_account_data.address,
+            chain_id,
+            ExecutionEncoding::New,
+        );
+
+        executable_account.set_block_id(BlockId::Tag(BlockTag::Pending));
+
+        let mut paymaster_accounts = vec![];
+        let mut executable_accounts = vec![];
+        for url in &setup_input.urls {
+            let provider = JsonRpcClient::new(HttpTransport::new(url.clone()));
+            let chain_id = get_chain_id(&provider).await?;
+
+            let paymaster_account = SingleOwnerAccount::new(
+                provider.clone(),
+                LocalWallet::from(paymaster_private_key),
+                setup_input.paymaster_account_address,
+                chain_id,
+                ExecutionEncoding::New,
+            );
+
+            let executable_account = SingleOwnerAccount::new(
+                provider.clone(),
+                LocalWallet::from(executable_account_data.signing_key),
+                executable_account_data.address,
+                chain_id,
+                ExecutionEncoding::New,
+            );
+
+            paymaster_accounts.push(paymaster_account);
+            executable_accounts.push(executable_account);
+        }
+
+        let random_executable_account = RandomSingleOwnerAccount {
+            accounts: executable_accounts,
+        };
+        let random_paymaster_account = RandomSingleOwnerAccount {
+            accounts: paymaster_accounts,
+        };
+
+        let (flattened_sierra_class, compiled_class_hash) =
+        get_compiled_contract(
+            PathBuf::from_str("target/dev/contracts_contracts_sample_contract_1_HelloStarknet.contract_class.json")?,
+        PathBuf::from_str("target/dev/contracts_contracts_sample_contract_1_HelloStarknet.compiled_contract_class.json")?,
+        )
+        .await?;
+
+        let declaration_result = match random_paymaster_account
+            .declare_v3(flattened_sierra_class, compiled_class_hash)
+            .send()
+            .await
+        {
+            Ok(result) => {
+                wait_for_sent_transaction_katana(
+                    result.transaction_hash,
+                    &random_paymaster_account.random_accounts()?,
+                )
+                .await?;
+                dev_client.generate_block().await?;
+                Ok(result)
+            }
+            Err(AccountError::Signing(sign_error)) => {
+                if sign_error.to_string().contains("is already declared") {
+                    Ok(ClassAndTxnHash {
+                        class_hash: parse_class_hash_from_error(&sign_error.to_string())?,
+                        transaction_hash: Felt::ZERO,
+                    })
+                } else {
+                    Err(OpenRpcTestGenError::RunnerError(
+                        RunnerError::AccountFailure(format!(
+                            "Transaction execution error: {}",
+                            sign_error
+                        )),
+                    ))
+                }
+            }
+
+            Err(AccountError::Provider(ProviderError::Other(starkneterror))) => {
+                if starkneterror.to_string().contains("is already declared") {
+                    Ok(ClassAndTxnHash {
+                        class_hash: parse_class_hash_from_error(&starkneterror.to_string())?,
+                        transaction_hash: Felt::ZERO,
+                    })
+                } else {
+                    Err(OpenRpcTestGenError::RunnerError(
+                        RunnerError::AccountFailure(format!(
+                            "Transaction execution error: {}",
+                            starkneterror
+                        )),
+                    ))
+                }
+            }
+            Err(e) => {
+                let full_error_message = format!("{:?}", e);
+
+                if full_error_message.contains("is already declared") {
+                    let class_hash = extract_class_hash_from_error(&full_error_message)?;
+
+                    let filter = EventFilterWithPageRequest {
+                        address: None,
+                        from_block: Some(BlockId::Number(322421)),
+                        to_block: Some(BlockId::Number(322421)),
+                        keys: Some(vec![vec![]]),
+                        chunk_size: 100,
+                        continuation_token: None,
+                    };
+
+                    let provider = random_paymaster_account.provider();
+                    let random_account_address =
+                        random_paymaster_account.random_accounts()?.address();
+
+                    let mut continuation_token = None;
+                    let mut found_txn_hash = None;
+
+                    loop {
+                        let mut current_filter = filter.clone();
+                        current_filter.continuation_token = continuation_token.clone();
+
+                        let events_chunk = provider.get_events(current_filter).await?;
+
+                        for event in events_chunk.events {
+                            if event.event.data.contains(&random_account_address) {
+                                let txn_hash = event.transaction_hash;
+
+                                let txn_details =
+                                    provider.get_transaction_by_hash(txn_hash).await?;
+
+                                if let Txn::Declare(DeclareTxn::V3(declare_txn)) = txn_details {
+                                    if declare_txn.class_hash == class_hash {
+                                        found_txn_hash = Some(txn_hash);
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+
+                        if found_txn_hash.is_some() {
+                            break;
+                        }
+
+                        if let Some(token) = events_chunk.continuation_token {
+                            continuation_token = Some(token);
+                        } else {
+                            break;
+                        }
+                    }
+
+                    if let Some(tx_hash) = found_txn_hash {
+                        Ok(ClassAndTxnHash {
+                            class_hash,
+                            transaction_hash: tx_hash,
+                        })
+                    } else {
+                        info!("Transaction hash not found for the declared clas");
+                        Err(OpenRpcTestGenError::RunnerError(
+                            RunnerError::AccountFailure(
+                                "Transaction hash not found for the declared class.".to_string(),
+                            ),
+                        ))
+                    }
+                } else {
+                    return Err(OpenRpcTestGenError::AccountError(AccountError::Other(
+                        full_error_message,
+                    )));
+                }
+            }
+        }?;
+
+        let factory = ContractFactory::new(
+            declaration_result.class_hash,
+            random_paymaster_account.random_accounts()?,
+        );
+        let mut salt_buffer = [0u8; 32];
+        let mut rng = StdRng::from_entropy();
+        rng.fill_bytes(&mut salt_buffer[1..]);
+
+        let deployment_result = factory
+            .deploy_v3(vec![], Felt::from_bytes_be(&salt_buffer), true)
+            .send()
+            .await?;
+
+        wait_for_sent_transaction_katana(
+            deployment_result.transaction_hash,
+            &random_paymaster_account.random_accounts()?,
+        )
+        .await?;
+        dev_client.generate_block().await?;
+
+        let deployment_receipt = random_paymaster_account
+            .provider()
+            .get_transaction_receipt(deployment_result.transaction_hash)
+            .await?;
+
+        let deployed_contract_address = match &deployment_receipt {
+            TxnReceipt::Deploy(receipt) => receipt.contract_address,
+            TxnReceipt::Invoke(receipt) => {
+                if let Some(contract_address) = receipt
+                    .common_receipt_properties
+                    .events
+                    .first()
+                    .and_then(|event| event.data.first())
+                {
+                    *contract_address
+                } else {
+                    return Err(OpenRpcTestGenError::CallError(
+                        CallError::UnexpectedReceiptType,
+                    ));
+                }
+            }
+            _ => {
+                return Err(OpenRpcTestGenError::CallError(
+                    CallError::UnexpectedReceiptType,
+                ));
+            }
+        };
+
+        dev_client.generate_block().await?;
+
+        Ok(Self {
+            random_executable_account,
+            random_paymaster_account,
+            paymaster_private_key: setup_input.paymaster_private_key,
+            account_class_hash: setup_input.account_class_hash,
+            udc_address: setup_input.udc_address,
+            deployed_contract_address,
+            dev_client,
+        })
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct DevClient {
+    pub url: Url,
+}
+
+impl DevClient {
+    pub fn new(url: Url) -> Self {
+        Self { url }
+    }
+
+    pub async fn generate_block(&self) -> Result<(), OpenRpcTestGenError> {
+        let client = reqwest::Client::new();
+        client
+            .post(self.url.clone())
+            .json(&serde_json::json!({
+                "jsonrpc": "2.0",
+                "method": "dev_generateBlock",
+                "params": [],
+                "id": 1
+            }))
+            .send()
+            .await
+            .map_err(OpenRpcTestGenError::RequestError)?;
+        Ok(())
+    }
+}
+
+pub async fn wait_for_sent_transaction_katana(
+    transaction_hash: Felt,
+    user_passed_account: &SingleOwnerAccount<JsonRpcClient<HttpTransport>, LocalWallet>,
+) -> Result<TxnFinalityAndExecutionStatus, OpenRpcTestGenError> {
+    let start_fetching = std::time::Instant::now();
+    let wait_for = Duration::from_secs(60);
+
+    info!(
+        "⏳ Waiting for transaction: {:?} to be mined.",
+        transaction_hash
+    );
+
+    loop {
+        if start_fetching.elapsed() > wait_for {
+            return Err(OpenRpcTestGenError::Timeout(format!(
+                "Transaction {:?} not mined in 60 seconds.",
+                transaction_hash
+            )));
+        }
+
+        // Check transaction status
+        let status = match user_passed_account
+            .provider()
+            .get_transaction_status(transaction_hash)
+            .await
+        {
+            Ok(status) => status,
+            Err(_e) => {
+                info!(
+                    "Error while checking status for transaction: {:?}. Retrying...",
+                    transaction_hash
+                );
+                tokio::time::sleep(Duration::from_secs(1)).await;
+                continue;
+            }
+        };
+
+        match status {
+            TxnFinalityAndExecutionStatus {
+                finality_status: TxnStatus::AcceptedOnL2,
+                execution_status: Some(TxnExecutionStatus::Succeeded),
+                ..
+            } => {
+                info!(
+                    "✅ Transaction {:?} Succeeded and accepted on L2. Finishing...",
+                    transaction_hash
+                );
+                return Ok(status);
+            }
+            TxnFinalityAndExecutionStatus {
+                finality_status: TxnStatus::AcceptedOnL2,
+                execution_status: Some(TxnExecutionStatus::Reverted),
+                ..
+            } => {
+                info!(
+                    "❌ Transaction {:?} reverted on L2. Stopping...",
+                    transaction_hash
+                );
+                return Err(OpenRpcTestGenError::TransactionFailed(
+                    transaction_hash.to_string(),
+                ));
+            }
+            TxnFinalityAndExecutionStatus {
+                finality_status: TxnStatus::Rejected,
+                ..
+            } => {
+                info!(
+                    "❌ Transaction {:?} rejected. Stopping...",
+                    transaction_hash
+                );
+                return Err(OpenRpcTestGenError::TransactionRejected(
+                    transaction_hash.to_string(),
+                ));
+            }
+            TxnFinalityAndExecutionStatus {
+                finality_status: TxnStatus::Received,
+                ..
+            } => {
+                info!(
+                    "🛎️ Transaction {:?} received. Retrying...",
+                    transaction_hash
+                );
+                tokio::time::sleep(Duration::from_secs(2)).await;
+                continue;
+            }
+            TxnFinalityAndExecutionStatus {
+                finality_status: TxnStatus::AcceptedOnL1,
+                ..
+            } => {
+                info!("✅ Transaction acceoted on L1. Finishing...");
+                return Ok(status);
+            }
+
+            _ => {
+                info!(
+                    "⏳ Transaction {} status not finalized. Retrying...",
+                    transaction_hash
+                );
+                tokio::time::sleep(Duration::from_secs(2)).await;
+                continue;
+            }
+        }
+    }
+}
+
+/// Represents a continuation token for implementing paging in event queries.
+///
+/// This struct stores the necessary information to resume fetching events
+/// from a specific point relative to the given filter passed as parameter to the
+/// `starknet_getEvents` API, [EventFilter][starknet::core::types::EventFilter].
+///
+/// There JSON-RPC specification does not specify the format of the continuation token,
+/// so how the node should handle it is implementation specific.
+#[derive(PartialEq, Eq, Debug, Clone, Default)]
+pub struct ContinuationToken {
+    /// The block number to continue from.
+    pub block_n: u64,
+    /// The transaction number within the block to continue from.
+    pub txn_n: u64,
+    /// The event number within the transaction to continue from.
+    pub event_n: u64,
+}
+
+impl ContinuationToken {
+    pub fn parse(token: &str) -> Result<Self, ContinuationTokenError> {
+        let arr: Vec<&str> = token.split(',').collect();
+        if arr.len() != 3 {
+            return Err(ContinuationTokenError::InvalidToken);
+        }
+        let block_n =
+            u64::from_str_radix(arr[0], 16).map_err(ContinuationTokenError::ParseFailed)?;
+        let receipt_n =
+            u64::from_str_radix(arr[1], 16).map_err(ContinuationTokenError::ParseFailed)?;
+        let event_n =
+            u64::from_str_radix(arr[2], 16).map_err(ContinuationTokenError::ParseFailed)?;
+
+        Ok(ContinuationToken {
+            block_n,
+            txn_n: receipt_n,
+            event_n,
+        })
+    }
+}
+
+impl fmt::Display for ContinuationToken {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:x},{:x},{:x}", self.block_n, self.txn_n, self.event_n)
+    }
+}
+
+#[cfg(not(feature = "rust-analyzer"))]
+include!(concat!(
+    env!("OUT_DIR"),
+    "/generated_tests_suite_katana_no_account_validation.rs"
+));

--- a/openrpc-testgen/src/suite_katana_no_account_validation/test_send_txs_with_invalid_signature.rs
+++ b/openrpc-testgen/src/suite_katana_no_account_validation/test_send_txs_with_invalid_signature.rs
@@ -1,0 +1,67 @@
+use crate::{
+    assert_eq_result,
+    utils::v7::{
+        accounts::{
+            account::{Account, ConnectedAccount},
+            call::Call,
+            creation::helpers::get_chain_id,
+            single_owner::{ExecutionEncoding, SingleOwnerAccount},
+        },
+        endpoints::{
+            errors::OpenRpcTestGenError,
+            utils::{get_selector_from_name, wait_for_sent_transaction},
+        },
+        signers::{key_pair::SigningKey, local_wallet::LocalWallet},
+    },
+    RandomizableAccountsTrait, RunnableTrait,
+};
+
+use starknet_types_core::felt::Felt;
+
+#[derive(Clone, Debug)]
+pub struct TestCase {}
+
+impl RunnableTrait for TestCase {
+    type Input = super::TestSuiteKatanaNoAccountValidation;
+    async fn run(test_input: &Self::Input) -> Result<Self, OpenRpcTestGenError> {
+        let account = test_input.random_paymaster_account.random_accounts()?;
+
+        let provider = account.provider().clone();
+
+        let chain_id = get_chain_id(&provider).await?;
+
+        let account_invalid = SingleOwnerAccount::new(
+            account.provider().clone(),
+            LocalWallet::from(SigningKey::from_random()),
+            account.address(),
+            chain_id,
+            ExecutionEncoding::New,
+        );
+        // initial sender's account nonce. use to assert how the txs validity change the account nonce.
+        let initial_nonce = account_invalid.get_nonce().await?;
+
+        let increase_balance_call = Call {
+            to: test_input.deployed_contract_address,
+            selector: get_selector_from_name("increase_balance")?,
+            calldata: vec![Felt::from_hex("0x50")?],
+        };
+
+        // -----------------------------------------------------------------------
+        //  transaction with invalid signatures.
+
+        // we set the max fee manually here to skip fee estimation. we want to test the pool validator.
+        let res = account_invalid
+            .execute_v1(vec![increase_balance_call])
+            .max_fee(Felt::from_hex_unchecked("0x1111111111111")) // Max fee 0x1111111111 too low with 0x1111111111111 working correctly.
+            .send()
+            .await;
+
+        wait_for_sent_transaction(res?.transaction_hash, &account_invalid).await?;
+
+        // nonce should be incremented by 1 after a valid tx.
+        let nonce = account_invalid.get_nonce().await?;
+        assert_eq_result!(initial_nonce + 1, nonce);
+
+        Ok(Self {})
+    }
+}

--- a/openrpc-testgen/src/suite_katana_no_fee/mod.rs
+++ b/openrpc-testgen/src/suite_katana_no_fee/mod.rs
@@ -1,0 +1,597 @@
+use core::fmt;
+use std::{path::PathBuf, str::FromStr, time::Duration};
+
+use rand::{rngs::StdRng, RngCore, SeedableRng};
+use starknet_types_core::felt::Felt;
+use starknet_types_rpc::{
+    BlockId, BlockTag, ClassAndTxnHash, DeclareTxn, EventFilterWithPageRequest, Txn,
+    TxnExecutionStatus, TxnFinalityAndExecutionStatus, TxnReceipt, TxnStatus,
+};
+use tracing::info;
+use url::Url;
+
+use crate::{
+    utils::{
+        random_single_owner_account::RandomSingleOwnerAccount,
+        v7::{
+            accounts::{
+                account::{Account, AccountError, ConnectedAccount},
+                call::Call,
+                creation::{
+                    create::{create_account, AccountType},
+                    helpers::get_chain_id,
+                },
+                single_owner::{ExecutionEncoding, SingleOwnerAccount},
+            },
+            contract::factory::ContractFactory,
+            endpoints::{
+                declare_contract::{
+                    extract_class_hash_from_error, get_compiled_contract,
+                    parse_class_hash_from_error, RunnerError,
+                },
+                errors::{CallError, ContinuationTokenError, OpenRpcTestGenError},
+                utils::get_selector_from_name,
+            },
+            providers::{
+                jsonrpc::{HttpTransport, JsonRpcClient},
+                provider::{Provider, ProviderError},
+            },
+            signers::{key_pair::SigningKey, local_wallet::LocalWallet},
+        },
+    },
+    RandomizableAccountsTrait, SetupableTrait,
+};
+pub mod test_deploy_account;
+pub mod test_send_txs_with_insufficient_fee;
+
+#[derive(Clone, Debug)]
+pub struct TestSuiteKatanaNoFee {
+    pub random_paymaster_account: RandomSingleOwnerAccount,
+    pub paymaster_private_key: Felt,
+    pub random_executable_account: RandomSingleOwnerAccount,
+    pub account_class_hash: Felt,
+    pub udc_address: Felt,
+    pub deployed_contract_address: Felt,
+    pub dev_client: DevClient,
+}
+
+#[derive(Clone, Debug)]
+pub struct SetupInput {
+    pub urls: Vec<Url>,
+    pub paymaster_account_address: Felt,
+    pub paymaster_private_key: Felt,
+    pub account_class_hash: Felt,
+    pub udc_address: Felt,
+}
+
+impl SetupableTrait for TestSuiteKatanaNoFee {
+    type Input = SetupInput;
+
+    async fn setup(setup_input: &Self::Input) -> Result<Self, OpenRpcTestGenError> {
+        let (executable_account_flattened_sierra_class, executable_account_compiled_class_hash) =
+            get_compiled_contract(
+                PathBuf::from_str("target/dev/contracts_ExecutableAccount.contract_class.json")?,
+                PathBuf::from_str(
+                    "target/dev/contracts_ExecutableAccount.compiled_contract_class.json",
+                )?,
+            )
+            .await
+            .unwrap();
+
+        let dev_client = DevClient::new(setup_input.urls[0].clone());
+
+        let provider = JsonRpcClient::new(HttpTransport::new(setup_input.urls[0].clone()));
+        let chain_id = get_chain_id(&provider).await?;
+
+        let paymaster_private_key =
+            SigningKey::from_secret_scalar(setup_input.paymaster_private_key);
+
+        let mut paymaster_account = SingleOwnerAccount::new(
+            provider.clone(),
+            LocalWallet::from(paymaster_private_key),
+            setup_input.paymaster_account_address,
+            chain_id,
+            ExecutionEncoding::New,
+        );
+
+        paymaster_account.set_block_id(BlockId::Tag(BlockTag::Pending));
+
+        let declare_executable_account_hash = match paymaster_account
+            .declare_v3(
+                executable_account_flattened_sierra_class.clone(),
+                executable_account_compiled_class_hash,
+            )
+            .send()
+            .await
+        {
+            Ok(result) => {
+                wait_for_sent_transaction_katana(result.transaction_hash, &paymaster_account)
+                    .await?;
+                dev_client.generate_block().await?;
+                Ok(result.class_hash)
+            }
+            Err(AccountError::Signing(sign_error)) => {
+                if sign_error.to_string().contains("is already declared") {
+                    Ok(parse_class_hash_from_error(&sign_error.to_string())?)
+                } else {
+                    Err(OpenRpcTestGenError::RunnerError(
+                        RunnerError::AccountFailure(format!(
+                            "Transaction execution error: {}",
+                            sign_error
+                        )),
+                    ))
+                }
+            }
+
+            Err(AccountError::Provider(ProviderError::Other(starkneterror))) => {
+                if starkneterror.to_string().contains("is already declared") {
+                    Ok(parse_class_hash_from_error(&starkneterror.to_string())?)
+                } else {
+                    Err(OpenRpcTestGenError::RunnerError(
+                        RunnerError::AccountFailure(format!(
+                            "Transaction execution error: {}",
+                            starkneterror
+                        )),
+                    ))
+                }
+            }
+            Err(e) => {
+                let full_error_message = format!("{:?}", e);
+                if full_error_message.contains("is already declared") {
+                    Ok(extract_class_hash_from_error(&full_error_message)?)
+                } else {
+                    Err(OpenRpcTestGenError::AccountError(AccountError::Other(
+                        full_error_message,
+                    )))
+                }
+            }
+        }?;
+
+        let executable_account_data = create_account(
+            &provider,
+            AccountType::Oz,
+            Option::None,
+            Some(declare_executable_account_hash),
+        )
+        .await?;
+
+        let deploy_executable_account_call: Call = Call {
+            to: setup_input.udc_address,
+            selector: get_selector_from_name("deployContract")?,
+            calldata: vec![
+                declare_executable_account_hash,
+                executable_account_data.salt,
+                Felt::ZERO,
+                Felt::ONE,
+                SigningKey::verifying_key(&executable_account_data.signing_key).scalar(),
+            ],
+        };
+
+        let deploy_executable_account_result = paymaster_account
+            .execute_v3(vec![deploy_executable_account_call])
+            .send()
+            .await?;
+
+        wait_for_sent_transaction_katana(
+            deploy_executable_account_result.transaction_hash,
+            &paymaster_account,
+        )
+        .await?;
+
+        dev_client.generate_block().await?;
+
+        let mut executable_account = SingleOwnerAccount::new(
+            provider.clone(),
+            LocalWallet::from(executable_account_data.signing_key),
+            executable_account_data.address,
+            chain_id,
+            ExecutionEncoding::New,
+        );
+
+        executable_account.set_block_id(BlockId::Tag(BlockTag::Pending));
+
+        let mut paymaster_accounts = vec![];
+        let mut executable_accounts = vec![];
+        for url in &setup_input.urls {
+            let provider = JsonRpcClient::new(HttpTransport::new(url.clone()));
+            let chain_id = get_chain_id(&provider).await?;
+
+            let paymaster_account = SingleOwnerAccount::new(
+                provider.clone(),
+                LocalWallet::from(paymaster_private_key),
+                setup_input.paymaster_account_address,
+                chain_id,
+                ExecutionEncoding::New,
+            );
+
+            let executable_account = SingleOwnerAccount::new(
+                provider.clone(),
+                LocalWallet::from(executable_account_data.signing_key),
+                executable_account_data.address,
+                chain_id,
+                ExecutionEncoding::New,
+            );
+
+            paymaster_accounts.push(paymaster_account);
+            executable_accounts.push(executable_account);
+        }
+
+        let random_executable_account = RandomSingleOwnerAccount {
+            accounts: executable_accounts,
+        };
+        let random_paymaster_account = RandomSingleOwnerAccount {
+            accounts: paymaster_accounts,
+        };
+
+        let (flattened_sierra_class, compiled_class_hash) =
+        get_compiled_contract(
+            PathBuf::from_str("target/dev/contracts_contracts_sample_contract_1_HelloStarknet.contract_class.json")?,
+        PathBuf::from_str("target/dev/contracts_contracts_sample_contract_1_HelloStarknet.compiled_contract_class.json")?,
+        )
+        .await?;
+
+        let declaration_result = match random_paymaster_account
+            .declare_v3(flattened_sierra_class, compiled_class_hash)
+            .send()
+            .await
+        {
+            Ok(result) => {
+                wait_for_sent_transaction_katana(
+                    result.transaction_hash,
+                    &random_paymaster_account.random_accounts()?,
+                )
+                .await?;
+                dev_client.generate_block().await?;
+                Ok(result)
+            }
+            Err(AccountError::Signing(sign_error)) => {
+                if sign_error.to_string().contains("is already declared") {
+                    Ok(ClassAndTxnHash {
+                        class_hash: parse_class_hash_from_error(&sign_error.to_string())?,
+                        transaction_hash: Felt::ZERO,
+                    })
+                } else {
+                    Err(OpenRpcTestGenError::RunnerError(
+                        RunnerError::AccountFailure(format!(
+                            "Transaction execution error: {}",
+                            sign_error
+                        )),
+                    ))
+                }
+            }
+
+            Err(AccountError::Provider(ProviderError::Other(starkneterror))) => {
+                if starkneterror.to_string().contains("is already declared") {
+                    Ok(ClassAndTxnHash {
+                        class_hash: parse_class_hash_from_error(&starkneterror.to_string())?,
+                        transaction_hash: Felt::ZERO,
+                    })
+                } else {
+                    Err(OpenRpcTestGenError::RunnerError(
+                        RunnerError::AccountFailure(format!(
+                            "Transaction execution error: {}",
+                            starkneterror
+                        )),
+                    ))
+                }
+            }
+            Err(e) => {
+                let full_error_message = format!("{:?}", e);
+
+                if full_error_message.contains("is already declared") {
+                    let class_hash = extract_class_hash_from_error(&full_error_message)?;
+
+                    let filter = EventFilterWithPageRequest {
+                        address: None,
+                        from_block: Some(BlockId::Number(322421)),
+                        to_block: Some(BlockId::Number(322421)),
+                        keys: Some(vec![vec![]]),
+                        chunk_size: 100,
+                        continuation_token: None,
+                    };
+
+                    let provider = random_paymaster_account.provider();
+                    let random_account_address =
+                        random_paymaster_account.random_accounts()?.address();
+
+                    let mut continuation_token = None;
+                    let mut found_txn_hash = None;
+
+                    loop {
+                        let mut current_filter = filter.clone();
+                        current_filter.continuation_token = continuation_token.clone();
+
+                        let events_chunk = provider.get_events(current_filter).await?;
+
+                        for event in events_chunk.events {
+                            if event.event.data.contains(&random_account_address) {
+                                let txn_hash = event.transaction_hash;
+
+                                let txn_details =
+                                    provider.get_transaction_by_hash(txn_hash).await?;
+
+                                if let Txn::Declare(DeclareTxn::V3(declare_txn)) = txn_details {
+                                    if declare_txn.class_hash == class_hash {
+                                        found_txn_hash = Some(txn_hash);
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+
+                        if found_txn_hash.is_some() {
+                            break;
+                        }
+
+                        if let Some(token) = events_chunk.continuation_token {
+                            continuation_token = Some(token);
+                        } else {
+                            break;
+                        }
+                    }
+
+                    if let Some(tx_hash) = found_txn_hash {
+                        Ok(ClassAndTxnHash {
+                            class_hash,
+                            transaction_hash: tx_hash,
+                        })
+                    } else {
+                        info!("Transaction hash not found for the declared clas");
+                        Err(OpenRpcTestGenError::RunnerError(
+                            RunnerError::AccountFailure(
+                                "Transaction hash not found for the declared class.".to_string(),
+                            ),
+                        ))
+                    }
+                } else {
+                    return Err(OpenRpcTestGenError::AccountError(AccountError::Other(
+                        full_error_message,
+                    )));
+                }
+            }
+        }?;
+
+        let factory = ContractFactory::new(
+            declaration_result.class_hash,
+            random_paymaster_account.random_accounts()?,
+        );
+        let mut salt_buffer = [0u8; 32];
+        let mut rng = StdRng::from_entropy();
+        rng.fill_bytes(&mut salt_buffer[1..]);
+
+        let deployment_result = factory
+            .deploy_v3(vec![], Felt::from_bytes_be(&salt_buffer), true)
+            .send()
+            .await?;
+
+        wait_for_sent_transaction_katana(
+            deployment_result.transaction_hash,
+            &random_paymaster_account.random_accounts()?,
+        )
+        .await?;
+        dev_client.generate_block().await?;
+
+        let deployment_receipt = random_paymaster_account
+            .provider()
+            .get_transaction_receipt(deployment_result.transaction_hash)
+            .await?;
+
+        let deployed_contract_address = match &deployment_receipt {
+            TxnReceipt::Deploy(receipt) => receipt.contract_address,
+            TxnReceipt::Invoke(receipt) => {
+                if let Some(contract_address) = receipt
+                    .common_receipt_properties
+                    .events
+                    .first()
+                    .and_then(|event| event.data.first())
+                {
+                    *contract_address
+                } else {
+                    return Err(OpenRpcTestGenError::CallError(
+                        CallError::UnexpectedReceiptType,
+                    ));
+                }
+            }
+            _ => {
+                return Err(OpenRpcTestGenError::CallError(
+                    CallError::UnexpectedReceiptType,
+                ));
+            }
+        };
+
+        dev_client.generate_block().await?;
+
+        Ok(Self {
+            random_executable_account,
+            random_paymaster_account,
+            paymaster_private_key: setup_input.paymaster_private_key,
+            account_class_hash: setup_input.account_class_hash,
+            udc_address: setup_input.udc_address,
+            deployed_contract_address,
+            dev_client,
+        })
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct DevClient {
+    pub url: Url,
+}
+
+impl DevClient {
+    pub fn new(url: Url) -> Self {
+        Self { url }
+    }
+
+    pub async fn generate_block(&self) -> Result<(), OpenRpcTestGenError> {
+        let client = reqwest::Client::new();
+        client
+            .post(self.url.clone())
+            .json(&serde_json::json!({
+                "jsonrpc": "2.0",
+                "method": "dev_generateBlock",
+                "params": [],
+                "id": 1
+            }))
+            .send()
+            .await
+            .map_err(OpenRpcTestGenError::RequestError)?;
+        Ok(())
+    }
+}
+
+pub async fn wait_for_sent_transaction_katana(
+    transaction_hash: Felt,
+    user_passed_account: &SingleOwnerAccount<JsonRpcClient<HttpTransport>, LocalWallet>,
+) -> Result<TxnFinalityAndExecutionStatus, OpenRpcTestGenError> {
+    let start_fetching = std::time::Instant::now();
+    let wait_for = Duration::from_secs(60);
+
+    info!(
+        "⏳ Waiting for transaction: {:?} to be mined.",
+        transaction_hash
+    );
+
+    loop {
+        if start_fetching.elapsed() > wait_for {
+            return Err(OpenRpcTestGenError::Timeout(format!(
+                "Transaction {:?} not mined in 60 seconds.",
+                transaction_hash
+            )));
+        }
+
+        // Check transaction status
+        let status = match user_passed_account
+            .provider()
+            .get_transaction_status(transaction_hash)
+            .await
+        {
+            Ok(status) => status,
+            Err(_e) => {
+                info!(
+                    "Error while checking status for transaction: {:?}. Retrying...",
+                    transaction_hash
+                );
+                tokio::time::sleep(Duration::from_secs(1)).await;
+                continue;
+            }
+        };
+
+        match status {
+            TxnFinalityAndExecutionStatus {
+                finality_status: TxnStatus::AcceptedOnL2,
+                execution_status: Some(TxnExecutionStatus::Succeeded),
+                ..
+            } => {
+                info!(
+                    "✅ Transaction {:?} Succeeded and accepted on L2. Finishing...",
+                    transaction_hash
+                );
+                return Ok(status);
+            }
+            TxnFinalityAndExecutionStatus {
+                finality_status: TxnStatus::AcceptedOnL2,
+                execution_status: Some(TxnExecutionStatus::Reverted),
+                ..
+            } => {
+                info!(
+                    "❌ Transaction {:?} reverted on L2. Stopping...",
+                    transaction_hash
+                );
+                return Err(OpenRpcTestGenError::TransactionFailed(
+                    transaction_hash.to_string(),
+                ));
+            }
+            TxnFinalityAndExecutionStatus {
+                finality_status: TxnStatus::Rejected,
+                ..
+            } => {
+                info!(
+                    "❌ Transaction {:?} rejected. Stopping...",
+                    transaction_hash
+                );
+                return Err(OpenRpcTestGenError::TransactionRejected(
+                    transaction_hash.to_string(),
+                ));
+            }
+            TxnFinalityAndExecutionStatus {
+                finality_status: TxnStatus::Received,
+                ..
+            } => {
+                info!(
+                    "🛎️ Transaction {:?} received. Retrying...",
+                    transaction_hash
+                );
+                tokio::time::sleep(Duration::from_secs(2)).await;
+                continue;
+            }
+            TxnFinalityAndExecutionStatus {
+                finality_status: TxnStatus::AcceptedOnL1,
+                ..
+            } => {
+                info!("✅ Transaction acceoted on L1. Finishing...");
+                return Ok(status);
+            }
+
+            _ => {
+                info!(
+                    "⏳ Transaction {} status not finalized. Retrying...",
+                    transaction_hash
+                );
+                tokio::time::sleep(Duration::from_secs(2)).await;
+                continue;
+            }
+        }
+    }
+}
+
+/// Represents a continuation token for implementing paging in event queries.
+///
+/// This struct stores the necessary information to resume fetching events
+/// from a specific point relative to the given filter passed as parameter to the
+/// `starknet_getEvents` API, [EventFilter][starknet::core::types::EventFilter].
+///
+/// There JSON-RPC specification does not specify the format of the continuation token,
+/// so how the node should handle it is implementation specific.
+#[derive(PartialEq, Eq, Debug, Clone, Default)]
+pub struct ContinuationToken {
+    /// The block number to continue from.
+    pub block_n: u64,
+    /// The transaction number within the block to continue from.
+    pub txn_n: u64,
+    /// The event number within the transaction to continue from.
+    pub event_n: u64,
+}
+
+impl ContinuationToken {
+    pub fn parse(token: &str) -> Result<Self, ContinuationTokenError> {
+        let arr: Vec<&str> = token.split(',').collect();
+        if arr.len() != 3 {
+            return Err(ContinuationTokenError::InvalidToken);
+        }
+        let block_n =
+            u64::from_str_radix(arr[0], 16).map_err(ContinuationTokenError::ParseFailed)?;
+        let receipt_n =
+            u64::from_str_radix(arr[1], 16).map_err(ContinuationTokenError::ParseFailed)?;
+        let event_n =
+            u64::from_str_radix(arr[2], 16).map_err(ContinuationTokenError::ParseFailed)?;
+
+        Ok(ContinuationToken {
+            block_n,
+            txn_n: receipt_n,
+            event_n,
+        })
+    }
+}
+
+impl fmt::Display for ContinuationToken {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:x},{:x},{:x}", self.block_n, self.txn_n, self.event_n)
+    }
+}
+
+#[cfg(not(feature = "rust-analyzer"))]
+include!(concat!(
+    env!("OUT_DIR"),
+    "/generated_tests_suite_katana_no_fee.rs"
+));

--- a/openrpc-testgen/src/suite_katana_no_fee/test_deploy_account.rs
+++ b/openrpc-testgen/src/suite_katana_no_fee/test_deploy_account.rs
@@ -1,0 +1,74 @@
+use crate::{
+    assert_eq_result, assert_matches_result,
+    utils::v7::{
+        accounts::{
+            account::ConnectedAccount,
+            deployment::helpers::get_contract_address,
+            factory::{open_zeppelin::OpenZeppelinAccountFactory, AccountFactory},
+        },
+        endpoints::{errors::OpenRpcTestGenError, utils::wait_for_sent_transaction},
+        providers::provider::Provider,
+        signers::{key_pair::SigningKey, local_wallet::LocalWallet, signer::Signer},
+    },
+    RandomizableAccountsTrait, RunnableTrait,
+};
+use starknet_types_core::felt::Felt;
+use starknet_types_rpc::{BlockId, BlockTag, DeployAccountTxnReceipt, TxnReceipt};
+
+const DEFAULT_ACCOUNT_CLASS_HASH: Felt =
+    Felt::from_hex_unchecked("0x07dc7899aa655b0aae51eadff6d801a58e97dd99cf4666ee59e704249e51adf2");
+
+#[derive(Clone, Debug)]
+pub struct TestCase {}
+
+impl RunnableTrait for TestCase {
+    type Input = super::TestSuiteKatanaNoFee;
+    async fn run(test_input: &Self::Input) -> Result<Self, OpenRpcTestGenError> {
+        let funding_account = test_input.random_paymaster_account.random_accounts()?;
+
+        let provider = test_input
+            .random_paymaster_account
+            .random_accounts()?
+            .provider()
+            .clone();
+        let chain_id = provider.chain_id().await?;
+
+        // Precompute the contract address of the new account with the given parameters:
+        let signer = LocalWallet::from(SigningKey::from_random());
+        let class_hash = DEFAULT_ACCOUNT_CLASS_HASH;
+        let salt = Felt::from_hex_unchecked("0x456");
+
+        let factory =
+            OpenZeppelinAccountFactory::new(class_hash, chain_id, &signer, &provider).await?;
+        let res = factory.deploy_v1(salt).send().await?;
+
+        let ctor_args = [signer.get_public_key().await?.scalar()];
+        let computed_address = get_contract_address(salt, class_hash, &ctor_args, Felt::ZERO);
+
+        // the contract address in the send tx result must be the same as the computed one
+        assert_eq_result!(res.contract_address, computed_address);
+
+        wait_for_sent_transaction(res.transaction_hash, &funding_account).await?;
+
+        let receipt = provider
+            .get_transaction_receipt(res.transaction_hash)
+            .await?;
+
+        assert_matches_result!(
+            receipt,
+            TxnReceipt::DeployAccount(DeployAccountTxnReceipt { contract_address, .. })  => {
+                // the contract address in the receipt must be the same as the computed one
+                assert_eq_result!(contract_address, computed_address)
+            }
+        );
+
+        // Verify the `getClassHashAt` returns the same class hash that we use for the account
+        // deployment
+        let res = provider
+            .get_class_hash_at(BlockId::Tag(BlockTag::Pending), computed_address)
+            .await?;
+        assert_eq_result!(res, class_hash);
+
+        Ok(Self {})
+    }
+}

--- a/openrpc-testgen/src/suite_katana_no_fee/test_send_txs_with_insufficient_fee.rs
+++ b/openrpc-testgen/src/suite_katana_no_fee/test_send_txs_with_insufficient_fee.rs
@@ -1,0 +1,85 @@
+use crate::{
+    assert_eq_result, assert_matches_result,
+    utils::v7::{
+        accounts::{
+            account::{Account, ConnectedAccount},
+            call::Call,
+        },
+        endpoints::{
+            errors::OpenRpcTestGenError,
+            utils::{get_selector_from_name, wait_for_sent_transaction},
+        },
+    },
+    RandomizableAccountsTrait, RunnableTrait,
+};
+
+use starknet_types_core::felt::Felt;
+
+pub const DEFAULT_PREFUNDED_ACCOUNT_BALANCE: u128 = 10 * u128::pow(10, 21);
+
+#[derive(Clone, Debug)]
+pub struct TestCase {}
+
+impl RunnableTrait for TestCase {
+    type Input = super::TestSuiteKatanaNoFee;
+    async fn run(test_input: &Self::Input) -> Result<Self, OpenRpcTestGenError> {
+        let account = test_input.random_paymaster_account.random_accounts()?;
+
+        let initial_nonce = account.get_nonce().await?;
+
+        let increase_balance_call = Call {
+            to: test_input.deployed_contract_address,
+            selector: get_selector_from_name("increase_balance")?,
+            calldata: vec![Felt::from_hex("0x50")?],
+        };
+
+        // -----------------------------------------------------------------------
+        //  transaction with low max fee (underpriced).
+
+        let res = account
+            .execute_v1(vec![increase_balance_call.clone()])
+            .max_fee(Felt::TWO)
+            .send()
+            .await;
+
+        // In no fee mode, the transaction resources (ie max fee) is totally ignored. So doesn't
+        // matter what value is set, the transaction will always be executed successfully.
+        assert_matches_result!(res, Ok(tx) => {
+            let tx_hash = tx.transaction_hash;
+            assert_matches_result!(wait_for_sent_transaction(tx_hash, &account).await, Ok(_));
+        });
+
+        let nonce = account.get_nonce().await?;
+        assert_eq_result!(
+            initial_nonce + 1,
+            nonce,
+            "Nonce should change in fee-disabled mode"
+        );
+
+        // -----------------------------------------------------------------------
+        //  transaction with insufficient balance.
+
+        let fee = Felt::from(DEFAULT_PREFUNDED_ACCOUNT_BALANCE + 1);
+
+        let res = account
+            .execute_v1(vec![increase_balance_call])
+            .max_fee(fee)
+            .send()
+            .await;
+
+        // in no fee mode, account balance is ignored. as long as the max fee (aka resources) is
+        // enough to at least run the account validation, the tx should be accepted.
+        // Wait for the transaction to be accepted
+        wait_for_sent_transaction(res?.transaction_hash, &account).await?;
+
+        // nonce should be incremented by 1 after a valid tx.
+        let nonce = account.get_nonce().await?;
+        assert_eq_result!(
+            initial_nonce + 2,
+            nonce,
+            "Nonce should change in fee-disabled mode"
+        );
+
+        Ok(Self {})
+    }
+}

--- a/openrpc-testgen/src/suite_katana_no_mining/mod.rs
+++ b/openrpc-testgen/src/suite_katana_no_mining/mod.rs
@@ -485,59 +485,11 @@ pub async fn wait_for_sent_transaction_katana(
                 execution_status: Some(TxnExecutionStatus::Succeeded),
                 ..
             } => {
+                info!(
+                    "✅ Transaction {:?} Succeeded and accepted on L2. Finishing...",
+                    transaction_hash
+                );
                 return Ok(status);
-                // info!(
-                //     "Transaction {:?} status: AcceptedOnL2 and Succeeded. Checking block inclusion...",
-                //     transaction_hash
-                // );
-
-                //     // Check if the transaction is in the pending block
-                //     let in_pending = match user_passed_account
-                //         .provider()
-                //         .get_block_with_tx_hashes(BlockId::Tag(BlockTag::Pending))
-                //         .await
-                //     {
-                //         Ok(MaybePendingBlockWithTxHashes::Pending(block)) => {
-                //             block.transactions.contains(&transaction_hash)
-                //         }
-                //         _ => false,
-                //     };
-
-                //     // Check if the transaction is in the latest block
-                //     let in_latest = match user_passed_account
-                //         .provider()
-                //         .get_block_with_tx_hashes(BlockId::Tag(BlockTag::Latest))
-                //         .await
-                //     {
-                //         Ok(MaybePendingBlockWithTxHashes::Block(block)) => {
-                //             block.transactions.contains(&transaction_hash)
-                //         }
-                //         _ => false,
-                //     };
-
-                //     if in_pending && !in_latest {
-                //         info!(
-                //             "Transaction {:?} is in Pending block but not yet in Latest block. Retrying...",
-                //             transaction_hash
-                //         );
-                //         tokio::time::sleep(Duration::from_secs(2)).await;
-                //         continue;
-                //     }
-
-                //     if in_latest && !in_pending {
-                //         info!(
-                //             "✅ Transaction {:?} confirmed in Latest block and not in Pending. Finishing...",
-                //             transaction_hash
-                //         );
-                //         return Ok(status);
-                //     }
-
-                //     info!(
-                //         "Transaction {:?} is neither in Latest nor finalized. Retrying...",
-                //         transaction_hash
-                //     );
-                //     tokio::time::sleep(Duration::from_secs(2)).await;
-                //     continue;
             }
             TxnFinalityAndExecutionStatus {
                 finality_status: TxnStatus::AcceptedOnL2,

--- a/openrpc-testgen/src/utils/v7/endpoints/errors.rs
+++ b/openrpc-testgen/src/utils/v7/endpoints/errors.rs
@@ -34,11 +34,17 @@ pub enum OpenRpcTestGenError {
     #[error(transparent)]
     SignError(#[from] SignError),
     #[error(transparent)]
+    GetPublicKeyError(#[from] crate::utils::v7::signers::local_wallet::Infallible),
+    #[error(transparent)]
     AccountError_(
         #[from] AccountError<crate::utils::v7::accounts::single_owner::SignError<SignError>>,
     ),
     #[error(transparent)]
     AccountError(#[from] AccountError<SignError>),
+    #[error(transparent)]
+    AccountFactoryError(
+        #[from] crate::utils::v7::accounts::factory::AccountFactoryError<SignError>,
+    ),
     #[error(transparent)]
     ProviderError(#[from] ProviderError),
     #[error(transparent)]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced `katana_no_fee` and `katana_no_account_validation` features for enhanced configurability in the OpenRPC TestGen framework.
  - Added support for new test suites: `TestSuiteKatanaNoFee` and `TestSuiteKatanaNoAccountValidation`.
  - Enhanced command-line interface with the ability to specify test suites for execution.
  - Implemented robust error handling for account deployment and transaction processing without fees or account validation.

- **Bug Fixes**
  - Improved error handling in transaction execution scenarios, ensuring accurate feedback for insufficient fees and balances.

- **Documentation**
  - Updated error handling documentation to reflect new error variants in the OpenRpcTestGenError enum.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->