### PR TITLE
Add possibility to choose suite after building with features.

### DIFF
--- a/openrpc-testgen-runner/src/args.rs
+++ b/openrpc-testgen-runner/src/args.rs
@@ -24,4 +24,14 @@ pub struct Args {
 
     #[arg(long, env, help = "Class hash of account contract")]
     pub account_class_hash: Felt,
+
+    #[arg(short, long, value_enum)]
+    pub suite: Vec<Suite>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, clap::ValueEnum)]
+pub enum Suite {
+    OpenRpc,
+    Katana,
+    KatanaNoMining,
 }

--- a/openrpc-testgen-runner/src/main.rs
+++ b/openrpc-testgen-runner/src/main.rs
@@ -1,4 +1,4 @@
-use args::Args;
+use args::{Args, Suite};
 use clap::Parser;
 #[allow(unused_imports)]
 use openrpc_testgen::{
@@ -7,6 +7,7 @@ use openrpc_testgen::{
     suite_openrpc::{SetupInput, TestSuiteOpenRpc},
     RunnableTrait,
 };
+use tracing::error;
 pub mod args;
 
 #[tokio::main]
@@ -17,41 +18,67 @@ async fn main() {
         .init();
     let args = Args::parse();
 
-    #[cfg(feature = "openrpc")]
-    {
-        let suite_openrpc_input = SetupInput {
-            urls: args.urls.clone(),
-            paymaster_account_address: args.paymaster_account_address,
-            paymaster_private_key: args.paymaster_private_key,
-            udc_address: args.udc_address,
-            account_class_hash: args.account_class_hash,
-        };
-
-        let _ = TestSuiteOpenRpc::run(&suite_openrpc_input).await;
-    }
-
-    #[cfg(feature = "katana")]
-    {
-        let suite_katana_input = SetupInputKatana {
-            urls: args.urls.clone(),
-            paymaster_account_address: args.paymaster_account_address,
-            paymaster_private_key: args.paymaster_private_key,
-            udc_address: args.udc_address,
-            account_class_hash: args.account_class_hash,
-        };
-
-        let _ = TestSuiteKatana::run(&suite_katana_input).await;
-    }
-    #[cfg(feature = "katana_no_mining")]
-    {
-        let suite_katana_input = SetupInputKatanaNoMining {
-            urls: args.urls.clone(),
-            paymaster_account_address: args.paymaster_account_address,
-            paymaster_private_key: args.paymaster_private_key,
-            udc_address: args.udc_address,
-            account_class_hash: args.account_class_hash,
-        };
-
-        let _ = TestSuiteKatanaNoMining::run(&suite_katana_input).await;
+    for suite in args.suite {
+        match suite {
+            Suite::OpenRpc => {
+                #[cfg(feature = "openrpc")]
+                {
+                    let suite_openrpc_input = SetupInput {
+                        urls: args.urls.clone(),
+                        paymaster_account_address: args.paymaster_account_address.clone(),
+                        paymaster_private_key: args.paymaster_private_key.clone(),
+                        udc_address: args.udc_address.clone(),
+                        account_class_hash: args.account_class_hash.clone(),
+                    };
+                    if let Err(e) = TestSuiteOpenRpc::run(&suite_openrpc_input).await {
+                        error!("Error while running TestSuiteOpenRpc: {}", e);
+                    }
+                }
+                #[cfg(not(feature = "openrpc"))]
+                {
+                    error!("Feature 'openrpc' not enabled during compilation phase.");
+                }
+            }
+            Suite::Katana => {
+                #[cfg(feature = "katana")]
+                {
+                    let suite_katana_input = SetupInputKatana {
+                        urls: args.urls.clone(),
+                        paymaster_account_address: args.paymaster_account_address.clone(),
+                        paymaster_private_key: args.paymaster_private_key.clone(),
+                        udc_address: args.udc_address.clone(),
+                        account_class_hash: args.account_class_hash.clone(),
+                    };
+                    if let Err(e) = TestSuiteKatana::run(&suite_katana_input).await {
+                        error!("Error while running TestSuiteKatana: {}", e);
+                    }
+                }
+                #[cfg(not(feature = "katana"))]
+                {
+                    error!("Feature 'katana' not enabled during compilation phase.");
+                }
+            }
+            Suite::KatanaNoMining => {
+                #[cfg(feature = "katana_no_mining")]
+                {
+                    let suite_katana_no_mining_input = SetupInputKatanaNoMining {
+                        urls: args.urls.clone(),
+                        paymaster_account_address: args.paymaster_account_address.clone(),
+                        paymaster_private_key: args.paymaster_private_key.clone(),
+                        udc_address: args.udc_address.clone(),
+                        account_class_hash: args.account_class_hash.clone(),
+                    };
+                    if let Err(e) =
+                        TestSuiteKatanaNoMining::run(&suite_katana_no_mining_input).await
+                    {
+                        error!("Error while running TestSuiteKatanaNoMining: {}", e);
+                    }
+                }
+                #[cfg(not(feature = "katana_no_mining"))]
+                {
+                    error!("Feature 'katana_no_mining' not enabled during compilation phase.");
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new command-line argument `suite` allowing users to specify test suites (`OpenRpc`, `Katana`, `KatanaNoMining`).
  
- **Improvements**
	- Enhanced error handling and control flow for running test suites, providing clearer error messages and logging.

- **Bug Fixes**
	- Streamlined execution flow for better performance and reliability during test suite execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->